### PR TITLE
Add support for using SymDiff as a library

### DIFF
--- a/Sources/SymDiff/source/BoogieUtil.cs
+++ b/Sources/SymDiff/source/BoogieUtil.cs
@@ -357,10 +357,22 @@ namespace SDiff.Boogie
       return name.StartsWith("_uf_");
     }
 
-    public static bool InjectUninterpreted(Procedure left, Procedure right, Config cfg, CallGraph cg, List<Declaration> ufDeclarations,bool asserts=false)
+    public static bool InjectUninterpreted(Procedure left,
+                                           Procedure right,
+                                           Config cfg,
+                                           CallGraph cg,
+                                           List<Declaration> ufDeclarations,
+                                           bool hasImplementation,
+                                           bool asserts=false)
     {
       if (left == null || right == null | ufDeclarations == null)
         return true;
+
+      if (!hasImplementation && left.Modifies.Count == 0)
+      {
+        Log.Out(Log.Urgent,
+          $"Compared procs {left}, {right} do not have bodies and any modifies clauses.");
+      }
 
       int i, j;
 

--- a/Sources/SymDiff/source/BoogieUtil.cs
+++ b/Sources/SymDiff/source/BoogieUtil.cs
@@ -371,7 +371,7 @@ namespace SDiff.Boogie
       if (!hasImplementation && left.Modifies.Count == 0)
       {
         Log.Out(Log.Urgent,
-          $"Compared procs {left}, {right} do not have bodies and any modifies clauses.");
+          $"Compared procedures {left}, {right} do not have bodies and do not have any modifies clauses.");
       }
 
       int i, j;

--- a/Sources/SymDiff/source/BoogieVerify.cs
+++ b/Sources/SymDiff/source/BoogieVerify.cs
@@ -47,6 +47,7 @@ namespace SDiff
     public class VerificationTask : Triple<Implementation, Implementation, Implementation>, IEmittable
     {
         public VerificationResult Result;
+        public SDiffCounterexamples Counterexamples;
         public List<Variable> DesiredOutputVars;
         public VerificationTask(Implementation eq, Implementation left, Implementation right)
             : base(eq, left, right)
@@ -904,6 +905,7 @@ namespace SDiff
                 newEq = (Implementation)newDict.Get(vt.Eq.Name + "$IMPL");
 
                 vt.Result = VerifyImplementation(vcgen, newEq, newProg, out SErrors);
+                vt.Counterexamples = SErrors;
 
                 switch (vt.Result)
                 {

--- a/Sources/SymDiff/source/BoogieVerify.cs
+++ b/Sources/SymDiff/source/BoogieVerify.cs
@@ -199,12 +199,18 @@ namespace SDiff
                 if (!imperativeBlocks.ContainsKey(b.Label))
                     imperativeBlocks.Add(b.Label, duper.VisitBlock(b));
 
+            var inlineOptPrev = BoogieUtils.BoogieOptions.ProcedureInlining;
+            if (Options.UnsoundRecursion)
+            {
+                BoogieUtils.BoogieOptions.ProcedureInlining = CoreOptions.Inlining.Spec;
+            }
             var engine = new ExecutionEngine(BoogieUtils.BoogieOptions, new VerificationResultCache(),
                 CustomStackSizePoolTaskScheduler.Create(16 * 1024 * 1024, 1));
             engine.EliminateDeadVariables(prog);
             engine.CoalesceBlocks(prog);
             engine.Inline(prog);
             engine.Dispose();
+            BoogieUtils.BoogieOptions.ProcedureInlining = inlineOptPrev;
 
             var assumeFlags = new QKeyValue(Token.NoToken, "captureState", new List<object>{ "final_state" }, null);
             AssumeCmd ac = new AssumeCmd(Token.NoToken, new LiteralExpr(Token.NoToken, true), assumeFlags);

--- a/Sources/SymDiff/source/Driver.cs
+++ b/Sources/SymDiff/source/Driver.cs
@@ -432,10 +432,6 @@ namespace SDiff
             var proc = d as Procedure;
             if (proc != null)
             {
-
-                if (Util.IsInlinedProc(proc))
-                    continue;
-
                 var pmap = new ParamMap();
                 foreach (Variable v in proc.InParams)
                     pmap.Add(new HDuple<string>(v.Name, v.Name));

--- a/Sources/SymDiff/source/MutualSummary.cs
+++ b/Sources/SymDiff/source/MutualSummary.cs
@@ -125,7 +125,7 @@ namespace SDiff
 
 
             var mpsPi = "mergedProgSingle_preInferred.bpl";
-            BoogieUtils.PrintProgram(program, mpsPi);
+            Util.DumpBplAST(program, mpsPi);
             program = BoogieUtils.ParseProgram(mpsPi);
             BoogieUtils.ResolveAndTypeCheckThrow(program, mpsPi, BoogieUtils.BoogieOptions); 
 
@@ -152,7 +152,7 @@ namespace SDiff
             var trueConstants = extractVariableAssigned(true, outcome);
             var falseConstants = extractVariableAssigned(false, outcome);
             persistHoudiniInferredFacts(trueConstants, falseConstants, program, houdini);
-            BoogieUtils.PrintProgram(program, "mergedProgSingle_inferred.bpl");
+            Util.DumpBplAST(program, "mergedProgSingle_inferred.bpl");
             Console.WriteLine("Houdini finished and inferred {0}/{1} contracts", trueConstants.Count, outcome.assignment.Count());
             Console.WriteLine("Houdini finished with {0} verified, {1} errors, {2} inconclusives, {3} timeouts",
                     outcome.Verified, outcome.ErrorCount, outcome.Inconclusives, outcome.TimeOuts);

--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -25,7 +25,7 @@ namespace SDiff
         public const bool PrintZ3Model = false;
         public const bool DumpBeforeVerifying = false;
         public static bool PropagateEquivs = true; //Changed to non constant to allow bogus modular checking
-        public const bool UnsoundRecursion = true;
+        public const bool UnsoundRecursion = false;
         public const bool DumpSymTrace = false;
         public static bool DoSymEx = true;
         public const bool CheckOutputsForMaps = false;

--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -25,7 +25,7 @@ namespace SDiff
         public const bool PrintZ3Model = false;
         public const bool DumpBeforeVerifying = false;
         public static bool PropagateEquivs = true; //Changed to non constant to allow bogus modular checking
-        public const bool UnsoundRecursion = false;
+        public const bool UnsoundRecursion = true;
         public const bool DumpSymTrace = false;
         public static bool DoSymEx = true;
         public const bool CheckOutputsForMaps = false;
@@ -38,6 +38,11 @@ namespace SDiff
         public static bool EnumerateAllPaths = false; //setting to true means we check assert(F) in EQ
         public static bool RVTOption = false; //RVT option
         public static string LoopStringIdentifier = "_loop_"; // if a function name contains this string we assume it was a loop converted into a recursive function.
+
+        // global variables with these strings in their name will be assumed to be modified in procedures with no
+        // implementations and no modifies clauses
+        public static List<string> HeapStringIdentifiers = ["heap", "Heap"];
+
         //mode where a procedure is inlined when not equal (non-recursive only) [For evaluation of diff inlining]
         public const bool InlineWhenFail = false; //make sure DifferentialInline is turned off
         #endregion

--- a/Sources/SymDiff/source/RVTCheck.cs
+++ b/Sources/SymDiff/source/RVTCheck.cs
@@ -138,7 +138,7 @@ namespace RVT
                 //Add the same uninterpreted function by default
                 Procedure leftP = cg.NodeOfName(fnPair.Key).Proc;
                 Procedure rightP = cg.NodeOfName(fnPair.Value).Proc;
-                InjectUIFsOnBothProcs(leftP, rightP);               
+                InjectUIFsOnBothProcs(leftP, rightP, cg.NodeOfName(fnPair.Key).Impl != null);               
                 if (RVTCreateEQProcs(left, ref synEq, ref empty1, ref empty2))
                 {
                     //add the mapping if the eq generation succeeded
@@ -179,13 +179,13 @@ namespace RVT
 
         }
 
-        private static void InjectUIFsOnBothProcs(Procedure leftP, Procedure rightP)
+        private static void InjectUIFsOnBothProcs(Procedure leftP, Procedure rightP, bool hasImplementation)
         {
             ////create uifs, grabs the readset from callgraph
             ////same uif for both versions   
             ////injects them as postcondition
             var newDecls = new List<Declaration>();
-            if (SDiff.Boogie.Process.InjectUninterpreted(leftP, rightP, cfg, cg, newDecls))
+            if (SDiff.Boogie.Process.InjectUninterpreted(leftP, rightP, cfg, cg, newDecls, hasImplementation))
                 Log.Out(Log.Error, "Failed to add postconditions to " + leftP.Name + " and " + rightP.Name);
             mergedProgram.AddTopLevelDeclarations(newDecls);
         }

--- a/Sources/SymDiff/source/RVTCheck.cs
+++ b/Sources/SymDiff/source/RVTCheck.cs
@@ -265,7 +265,7 @@ namespace RVT
             string eqpName = Transform.mkEqProcName(n1.Name, n2.Name);
 
             Duple<Procedure, Implementation> eqp;
-            eqp = Transform.EqualityReduction(n1.Impl, n2.Impl, cfg.FindProcedure(n1.Name, n2.Name), ignores, out outputVars);
+            eqp = Transform.EqualityReduction(n1.Impl, n2.Impl, cfg.FindProcedure(n1.Name, n2.Name), ignores, out outputVars, out _);
 
             // if any visible output
             //VerificationTask vt;

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -1103,9 +1103,9 @@ namespace SDiff
                 }
 
                 // Creates EQ_f_f' function
-                List<Variable> outputVars;
                 var eqp =
-                  Transform.EqualityReduction(n1.Impl, n2.Impl, cfg.FindProcedure(n1.Name, n2.Name), ignores, out outputVars);
+                  Transform.EqualityReduction(n1.Impl, n2.Impl, cfg.FindProcedure(n1.Name, n2.Name), ignores,
+                      out var outputVars, out var eqProcParamInfo);
 
                 //RS: adding OK1=true, OK2=true, and OK1=>OK2
                 if (Options.checkAssertsOnly)
@@ -1237,7 +1237,7 @@ namespace SDiff
                             numCex += numCexOfVt;
                             failedImpls.Add(vt.Left.Name);
                         }
-                        equivalenceResults.Add(new EquivalenceResult(n1.Name, n2.Name, vt.Result, vt.Counterexamples));
+                        equivalenceResults.Add(new EquivalenceResult(n1.Name, n2.Name, vt.Result, vt.Counterexamples, eqProcParamInfo));
                     }
 
                     //totClock.Stop();
@@ -1700,16 +1700,36 @@ namespace SDiff
     public class EquivalenceResult(string procedure1,
                                    string procedure2,
                                    VerificationResult verificationResult,
-                                   SDiffCounterexamples counterexamples)
+                                   SDiffCounterexamples counterexamples,
+                                   EqualityProcedureParameterInfo parameterInfo)
     {
         public string Procedure1 { get; } = procedure1;
         public string Procedure2 { get; } = procedure2;
         public VerificationResult VerificationRunResult { get; } = verificationResult;
         public SDiffCounterexamples Counterexamples { get; } = counterexamples;
+        public EqualityProcedureParameterInfo ParameterInfo { get; } = parameterInfo;
         public override string ToString()
         {
             return $"{Procedure1} == {Procedure2}: {VerificationRunResult}";
         }
+    }
+
+    public class EqualityProcedureParameterInfo(
+        List<string> proc1InParams,
+        List<string> proc1OutParams,
+        List<string> proc2InParams,
+        List<string> proc2OutParams,
+        List<string> globals,
+        List<string> globalsAtEntry,
+        List<string> globalsAfterProc1Return)
+    {
+        public List<string> Proc1InParams { get; } = proc1InParams;
+        public List<string> Proc1OutParams { get; } = proc1OutParams;
+        public List<string> Proc2InParams { get; } = proc2InParams;
+        public List<string> Proc2OutParams { get; } = proc2OutParams;
+        public List<string> Globals { get; } = globals;
+        public List<string> GlobalsAtEntry { get; } = globalsAtEntry;
+        public List<string> GlobalsAfterProc1Return { get; } = globalsAfterProc1Return;
     }
 
     public class VerificationException(string message) : Exception(message);

--- a/Sources/SymDiffPreProcess/source/SmackPreprocessorTransform.cs
+++ b/Sources/SymDiffPreProcess/source/SmackPreprocessorTransform.cs
@@ -168,7 +168,7 @@ namespace SymdiffPreprocess
             bool firstSourceInfoAssert = false; 
             foreach(var cmd in cmds)
             {
-                if (!Util.IsSourceInfoAssertCmd(cmd))
+                if (!Util.IsSourceInfoAssertOrAssumeCmd(cmd))
                 {
                     currBlock.Cmds.Add(cmd);
                     continue;

--- a/Sources/SymDiffUtils/boogieUtils.cs
+++ b/Sources/SymDiffUtils/boogieUtils.cs
@@ -20,17 +20,6 @@ namespace SymDiffUtils
 
             return false;
         }
-        //call with null filename to print to console
-        public static void PrintProgram(Program p, string filename)
-        {
-            TokenTextWriter outFile;
-            if (filename != null)
-                outFile = new TokenTextWriter(filename, true, BoogieOptions);
-            else
-                outFile = new TokenTextWriter(Console.Out, true, BoogieOptions);
-            p.Emit(outFile);
-            outFile.Close();
-        }
 
         public static bool ResolveProgram(Program p, string filename, CommandLineOptions boogieOptions)
         {

--- a/Sources/SyntaxDiff/Program.cs
+++ b/Sources/SyntaxDiff/Program.cs
@@ -227,7 +227,7 @@ namespace SyntaxDiff
     {
         public override Cmd VisitAssertCmd(AssertCmd node)
         {
-            if (Util.IsSourceInfoAssertCmd(node))
+            if (Util.IsSourceInfoAssertOrAssumeCmd(node))
             {
                 node.Attributes = null; 
             }
@@ -265,11 +265,11 @@ namespace SyntaxDiff
                 impl.Blocks
                     .ForEach(b =>
                     {
-                        b.Cmds.Where(c => Util.IsSourceInfoAssertCmd(c))
+                        b.Cmds.Where(c => Util.IsSourceInfoAssertOrAssumeCmd(c))
                             .ForEach(ac =>
                             {
                                 int srcLine;
-                                Util.IsSourceInfoAssertCmd(ac, out srcFile, out srcLine);
+                                Util.IsSourceInfoAssertOrAssumeCmd(ac, out srcFile, out srcLine);
                                 srcFiles.Add(srcFile);
                                 lines.Add(srcLine);
                             });
@@ -286,7 +286,7 @@ namespace SyntaxDiff
             foreach(var src in srcFiles)
             {
                 var contentSrc = new List<string>();
-                using (var srcStream = new StreamReader(Path.Combine(bplPath, src)))
+                using (var srcStream = new StreamReader(src))
                 {
                     while (srcStream.Peek() >= 0) { contentSrc.Add(srcStream.ReadLine().Trim()); }
                 }


### PR DESCRIPTION
Added a wrapper `AllInOneMainWithResult` that returns verification results for each compared procedure as a list of `EquivalenceResult`s.

For printing counterexamples, the returned `EquivalenceResult` also maintains a list of inputs, outputs and globals, along with their values in the counterexample model. A small change was also made to the merged program to save inputs into separate variables.

### Other changes
- Added support for comparing singly-recursive procedures to standard SymDiff in this [commit](https://github.com/boogie-org/symdiff/commit/84e98b0ba9225544bb3bffcb2a80f1427ec8d305). It relies on inlining recursive procedures using the spec option (as also done by the RVT implementation). This is unsound when comparing mutually recursive procedures, i.e.,  when verification fails for at least one procedure in a mutual recursion call graph (which is a SCC), the others nodes of the same SCC can be marked as verified.
- When a procedure does not have a corresponding implementation and no modifies clauses, the set of globals containing an identifier (that can be modified, by default `heap` and `Heap`) in their names will be added to that procedure's modified set.
- Inlined procedures are now also compared when they are specified in the configuration file for comparison.