### PR TITLE
Adds block outlining and loop extraction to standard SymDiff

### DIFF
--- a/Sources/SymDiff/source/BlockOutliner.cs
+++ b/Sources/SymDiff/source/BlockOutliner.cs
@@ -29,8 +29,6 @@ public static class BlockOutliner
     /// <summary>
     /// Outlines the passed Block, i.e., extracts it as a procedure.
     /// The passed Implementation and Program are updated in-place.
-    /// blockNameToUseInExtractedImpl: optionally specify a custom block name
-    ///     to be used in the extracted implementation's name. This is useful
     /// </summary>
     public static Implementation OutlineBlock(CoreOptions options,
                                               Program program, 
@@ -112,10 +110,11 @@ public static class BlockOutliner
             containingImpl.InParams, containingImpl.OutParams,
             containingImpl.LocVars, unrolledBlocks);
         new SymDiff.source.LiveVariableAnalysis(options).ComputeLiveVariables(unrolledImpl, globals);
-        var unrollingsOfBlock = containingImpl.Blocks.ToDictionary(b1 => b1,
-            b1 => unrolledBlocks.Where(b2 => b2.Label.Equals(b1.Label + "#0") ||
-                                             b2.Label.Equals(b1.Label + "#1") ||
-                                             b2.Label.Equals(b1.Label + "#2")));
+        var unrollingsOfBlock = containingImpl.Blocks.ToDictionary(
+            b1 => b1,
+            b1 => unrolledBlocks.Where(b2 => Enumerable.Range(0, 3) // i.e., (0, 2]
+                .Any(i => b2.Label.Equals(b1.Label + $"#{i}")))
+        );
 
         var liveVarsBefore = new HashSet<Variable>();
         var liveVarsAfter = new HashSet<Variable>();

--- a/Sources/SymDiff/source/BlockOutliner.cs
+++ b/Sources/SymDiff/source/BlockOutliner.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Boogie;
+
+namespace SymDiff.source;
+
+public static class BlockOutliner
+{
+    // Outlining might not be sound (for partial equivalence) if the outlined
+    // block contains assume statements. If relative termination is also checked,
+    // then this check can be disabled.
+    public static bool IsSoundForOutlining(this Block block)
+    {
+        var assumeCmds = block.Cmds.Where(c =>
+            c is AssumeCmd { Expr: not LiteralExpr }).ToList();
+        if (assumeCmds.Count == 0) return true;
+
+        foreach (var cmd in assumeCmds)
+        {
+            var c = new VariableCollector();
+            c.Visit(cmd);
+            if (c.usedVars.Any()) return false;
+        }
+
+        return true;
+    }
+    
+    /// <summary>
+    /// Outlines the passed Block, i.e., extracts it as a procedure.
+    /// The passed Implementation and Program are updated in-place.
+    /// blockNameToUseInExtractedImpl: optionally specify a custom block name
+    ///     to be used in the extracted implementation's name. This is useful
+    /// </summary>
+    public static Implementation OutlineBlock(CoreOptions options,
+                                              Program program, 
+                                              Implementation containingImpl,
+                                              Block block)
+    {
+        var globals = program.TopLevelDeclarations.OfType<GlobalVariable>().ToHashSet();
+        var blockImpl = Outline(block, containingImpl, globals, options);
+
+        program.AddTopLevelDeclaration(blockImpl);
+        program.AddTopLevelDeclaration(blockImpl.Proc);
+
+        return blockImpl;
+    }
+
+    private static Implementation Outline(Block block,
+                                          Implementation containingImpl,
+                                          HashSet<GlobalVariable> globals,
+                                          CoreOptions options)
+    {
+        /*
+         *   block:
+         *       [block_body]
+         *       goto block_next;
+         *
+         * is outlined as
+         * 
+         *   block:
+         *       call outs := block_body_impl(ins);
+         *       goto block_next;
+         *   [...]
+         * 
+         *   procedure block_body_impl(proc_ins) returns (proc_outs)
+         *       modifies [subset of globals that are in block_body]
+         * 
+         *   implementation block_body_impl(proc_ins) returns (proc_outs)
+         *   {
+         *       var locals; // declare locals that only appear in this block
+         *                   // and copies of input variables
+         *       block entry:
+         *           [assign some ins that appear as outs]
+         *           goto block;
+         *       block:
+         *           [block_body] with subst(v, proc_v)
+         *           return;
+         *   }   
+         * 
+         *  ins  : Non-global variables where
+         *             1) the variable is live before the block
+         *             2) the variable is in the footprint of the block
+         *         I.e. variables whose values are actually needed.
+         *  outs : Non-global variables where
+         *             1) the variable is live after the block
+         *             2) the variable is modified within the block
+         *         I.e., values that the block is responsible for and that are
+         *         used after the block.
+         *         We also add all ins to outs, because there might be assume
+         *         statements over them.
+         */
+
+        var modifiedVars     = new List<Variable>();
+        var footprint        = new HashSet<Variable>();
+
+        // Collect used and assigned variables within the block
+        foreach (var cmd in block.Cmds)
+        {
+            cmd.AddAssignedVariables(modifiedVars);
+
+            var c = new VariableCollector();
+            c.Visit(cmd);
+            footprint.UnionWith(c.usedVars);
+        }
+
+        // Create a 2-unrolled implementation and apply live-variable analysis.
+        // Unrolling is needed for ComputeLiveVariables to work.
+        var unrolledBlocks = LoopUnroll.UnrollLoops(containingImpl.Blocks[0], 2, false);
+        var unrolledImpl = new Implementation(Token.NoToken,
+            containingImpl.Name + "unrolled", containingImpl.TypeParameters,
+            containingImpl.InParams, containingImpl.OutParams,
+            containingImpl.LocVars, unrolledBlocks);
+        new SymDiff.source.LiveVariableAnalysis(options).ComputeLiveVariables(unrolledImpl, globals);
+        var unrollingsOfBlock = containingImpl.Blocks.ToDictionary(b1 => b1,
+            b1 => unrolledBlocks.Where(b2 => b2.Label.Equals(b1.Label + "#0") ||
+                                             b2.Label.Equals(b1.Label + "#1") ||
+                                             b2.Label.Equals(b1.Label + "#2")));
+
+        var liveVarsBefore = new HashSet<Variable>();
+        var liveVarsAfter = new HashSet<Variable>();
+
+        if (unrollingsOfBlock.TryGetValue(block, out var unrollings))
+        {
+            foreach (var blk in unrollings)
+            {
+                blk.liveVarsBefore.ForEach(v => liveVarsBefore.Add(v));
+                if (blk.TransferCmd is not GotoCmd cmd) continue;
+                foreach (var blkTarget in cmd.labelTargets)
+                {
+                    var targetUnrollings = unrollingsOfBlock.Where(b =>
+                            blkTarget.Label.Equals(b.Key.Label + "#0") ||
+                            blkTarget.Label.Equals(b.Key.Label + "#1") ||
+                            blkTarget.Label.Equals(b.Key.Label + "#2")).SelectMany(p => p.Value).ToList();
+                    if (targetUnrollings.Count == 0) continue;
+                    targetUnrollings.ForEach(b => b.liveVarsBefore.ForEach(v => liveVarsAfter.Add(v)));
+                    // {
+                    //     if (liveVarsBefore.Count == 0) liveVarsBefore = footprint;
+                    //     if (liveVarsAfter.Count == 0) liveVarsAfter = globals.Select(v => v as Variable).ToHashSet();
+                    // };
+                }
+            }
+        }
+
+        var newImplIns     = new List<Variable>();
+        var newImplOuts    = new List<Variable>();
+        var substMap       = new Dictionary<Variable, IdentifierExpr>();
+        var initAssigns    = new List<Cmd>();
+        var finalAssigns   = new List<Cmd>();
+        var localsForIns   = new List<LocalVariable>();
+        var callSiteIns    = new List<Expr>();
+        var callSiteOuts   = new List<IdentifierExpr>();
+
+        var containingImplNonGlobals = containingImpl.InParams
+            .Concat(containingImpl.OutParams)
+            .Concat(containingImpl.LocVars).ToList();
+
+        // 1) the variable is live before the block
+        // 2) the variable is in the footprint of the block
+        var inVars = containingImplNonGlobals.Where(v =>
+            liveVarsBefore.Contains(v) && footprint.Contains(v))
+            .OrderBy(v => v.Name).ToList();
+
+        // 1) the variable is live after the block
+        // 2) the variable is modified within the block
+        var outVars = containingImplNonGlobals.Where(v =>
+            liveVarsAfter.Contains(v) && modifiedVars.Contains(v))
+            //.Concat(inVars).Distinct() // add all ins as outputs too
+            .OrderBy(v => v.Name).ToList();
+
+        // The inputs of the new implementation
+        foreach (var v in inVars)
+        {
+            // Add v to the list of arguments to the new impl at call site
+            callSiteIns.Add(new IdentifierExpr(Token.NoToken, v));
+
+            // Declare a new formal f for the signature of the new impl
+            var f = new Formal(Token.NoToken,
+                new TypedIdent(Token.NoToken, "in_" + newImplIns.Count, v.TypedIdent.Type), true);
+
+            // Copy inputs to local variables in case they are modified
+            var vLocal = new LocalVariable(Token.NoToken,
+                new TypedIdent(Token.NoToken, f.Name + "_loc", v.TypedIdent.Type));
+            localsForIns.Add(vLocal);
+            var vLocalExpr = new IdentifierExpr(Token.NoToken, vLocal);
+            var initLhs = new SimpleAssignLhs(Token.NoToken, vLocalExpr);
+            var initRhs = new IdentifierExpr(Token.NoToken, f);
+            initAssigns.Add(new AssignCmd(Token.NoToken, [ initLhs ], [ initRhs ]));
+
+            // Substitute v with the local version in the body
+            substMap.Add(v, vLocalExpr);
+
+            newImplIns.Add(f);
+        }
+
+        // The outputs of the new implementation
+        foreach (var v in outVars)
+        {
+            // Add v to the list of outputs of the new impl at call site
+            callSiteOuts.Add(new IdentifierExpr(Token.NoToken, v));
+            var f = new Formal(Token.NoToken,
+                new TypedIdent(Token.NoToken, "out_" + newImplOuts.Count, v.TypedIdent.Type), false);
+            var fExpr = new IdentifierExpr(Token.NoToken, f);
+            
+            // If this variable also appears in the input, it will already be in
+            // the subst map. This means we don't need a substitution in the body,
+            // but must assign to the new out variable before return.
+            if (substMap.TryGetValue(v, out var vLocalExpr))
+            {
+                var lhs = new SimpleAssignLhs(Token.NoToken, fExpr);
+                finalAssigns.Add(new AssignCmd(Token.NoToken, [ lhs ], [ vLocalExpr ]));
+            }
+            else
+            {
+                substMap.Add(v, fExpr);
+            }
+
+            newImplOuts.Add(f);
+        }
+
+        // Create the new procedure and the call command
+        var modifiedGlobals = globals.Intersect(modifiedVars);
+        var modifiedGlobalExprs = modifiedGlobals.Select(v => new IdentifierExpr(Token.NoToken, v)).ToList();
+        var blockProc = new Procedure(Token.NoToken, $"{containingImpl.Name}_outlined_block_{block}",
+            typeParams:[], newImplIns, newImplOuts, isPure:false,
+            requires:[], modifiedGlobalExprs, ensures:[]);
+
+        var callCmd = new CallCmd(Token.NoToken, blockProc.Name, callSiteIns, callSiteOuts)
+        {
+            Proc = blockProc
+        };
+
+        // Create the new implementation
+
+        var locals = footprint.Where(v => containingImplNonGlobals.Contains(v) && // not a global
+                                          !substMap.ContainsKey(v));
+
+        var newLocals = new List<Variable>();
+
+        foreach (var v in locals)
+        {
+            var newV = new LocalVariable(v.tok, v.TypedIdent);
+            newLocals.Add(newV);
+            substMap.Add(v, new IdentifierExpr(newV.tok, newV.Name));
+        }
+
+        var newImplLocals = newLocals.Concat(localsForIns).ToList(); 
+
+        var subst = Substituter.SubstitutionFromDictionary(
+            substMap.ToDictionary(p => p.Key, p => p.Value as Expr));
+
+        var finalBlock = new Block
+        {
+            Label = $"{containingImpl.Name}_block_{block}_exit",
+            Cmds = finalAssigns,
+            TransferCmd = new ReturnCmd(Token.NoToken)
+        };
+
+        var newBlock = new Block
+        {
+            Label = block.Label,
+            Cmds = Substituter.Apply(subst, block.Cmds),
+            TransferCmd = new GotoCmd(Token.NoToken, [finalBlock])
+        };
+
+        var initBlock = new Block
+        {
+            Label = $"{containingImpl.Name}_block_{block}_entry",
+            Cmds = initAssigns,
+            TransferCmd = new GotoCmd(Token.NoToken, [newBlock])
+        };
+
+        var blockImpl = new Implementation(Token.NoToken, blockProc.Name, [],
+            newImplIns, newImplOuts, newImplLocals.OrderBy(v => v.Name).ToList(),
+            [ initBlock, newBlock, finalBlock ])
+        {
+            Proc = blockProc
+        };
+
+        // Replace block body with call to extracted procedure
+        block.Cmds = [ callCmd ];
+        containingImpl.StructuredStmts = null; // The structured statements are no longer up-to-date.
+
+        return blockImpl;
+    }
+}

--- a/Sources/SymDiff/source/BoogieStructuralDiffManager.cs
+++ b/Sources/SymDiff/source/BoogieStructuralDiffManager.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Microsoft.Boogie;
+using Microsoft.Boogie.GraphUtil;
+
+namespace SymDiff.source;
+
+public static class BoogieStructuralDiffManager
+{
+  // This is currently quite restrictive, but should work for simple changes
+  // that do not change the control flow, and should be insensitive to block
+  // labels.
+  public static bool CanComputeDiff(this Implementation implA, Implementation implB,
+                                    out Dictionary<Block, Block> blockMapping)
+  {
+    blockMapping = new Dictionary<Block, Block>();
+    if (implA.Blocks == null || implB.Blocks == null || implA.Blocks.Count != implB.Blocks.Count) 
+      return false;
+    Graph<Block> graphA = Program.GraphFromImpl(implA);
+    Graph<Block> graphB = Program.GraphFromImpl(implB);
+    if (graphA.Edges.Count() != graphB.Edges.Count())
+      return false;
+    // TODO: use a graph isomorphism below rather than ordering by name!
+    foreach (var ((blkA1, blkA2), (blkB1, blkB2)) in
+             graphA.Edges.OrderBy(p => p.Item1.Label)
+               .Zip(graphB.Edges.OrderBy(p => p.Item1.Label)))
+    {
+      var blocksToCompare = new List<(Block, Block)>{ (blkA1, blkB1), (blkA2, blkB2) };
+      foreach (var (blkA, blkB) in blocksToCompare)
+      {
+        if (blockMapping.TryGetValue(blkA, out var blkInMap))
+        {
+          if (!blkInMap.Label.Equals(blkB.Label))
+          {
+            blockMapping.Clear();
+            return false;
+          }
+        }
+        else
+        {
+          blockMapping.Add(blkA, blkB);
+        }
+      }
+    }
+
+    return true;
+  }
+  
+  public static Dictionary<Block, Block> GetBlocksThatDiffer(this Implementation implA,
+                                                             Implementation implB,
+                                                             Dictionary<Block, Block> blockMapping,
+                                                             ReadOnlyDictionary<string, string> functionMapping)
+  {
+    Dictionary<Block, Block> blocksThatDiffer = new();
+    var comparer = new ImplementationComparer(functionMapping);
+    foreach (var (blkA, blkB) in blockMapping)
+    {
+      if (!comparer.Compare(blkA, blkB))
+      {
+        blocksThatDiffer.Add(blkA, blkB);
+      }
+    }
+    
+    foreach (var (blkA, blkB) in comparer.blockMapping)
+      if (blockMapping[blkA] != blkB)
+        throw new Exception("Inconsistent block mapping!");
+
+    return blocksThatDiffer;
+  }
+}

--- a/Sources/SymDiff/source/BoogieVerify.cs
+++ b/Sources/SymDiff/source/BoogieVerify.cs
@@ -505,13 +505,22 @@ namespace SDiff
         {
             //inlining Cex (trace) within the Diff_inline body
             var impName = errors[0].Impl.Name.Replace("EQ_", "");
-            var index = impName.IndexOf("__xx__"); //avoid aliasing with funcs with x___y names
-            var v1Name = impName.Substring(0, index);
-            var v2Name = impName.Substring(index + 6);
-            var indexPointV1Name = v1Name.IndexOf(".");
-            var indexPointV2Name = v2Name.IndexOf(".");
-            v1Name = v1Name.Substring(0, indexPointV1Name);
-            v2Name = v2Name.Substring(0, indexPointV2Name);
+            string v1Name, v2Name;
+            if (impName.Contains("__xx__"))
+            {
+                var index = impName.IndexOf("__xx__"); //avoid aliasing with funcs with x___y names
+                v1Name = impName.Substring(0, index);
+                v2Name = impName.Substring(index + 6);
+                var indexPointV1Name = v1Name.IndexOf(".");
+                var indexPointV2Name = v2Name.IndexOf(".");
+                v1Name = v1Name.Substring(0, indexPointV1Name);
+                v2Name = v2Name.Substring(0, indexPointV2Name);
+            }
+            else
+            {
+                v1Name = impName;
+                v2Name = impName;
+            }
 
             ProcessCounterexamplesWOSymbolicOut(errors, globals, eqLocVars, vtLeftProcImpl, vtRightProcImpl, consts, errModelList, v1Name, v2Name);
         }

--- a/Sources/SymDiff/source/BoogieVerify.cs
+++ b/Sources/SymDiff/source/BoogieVerify.cs
@@ -508,13 +508,9 @@ namespace SDiff
             string v1Name, v2Name;
             if (impName.Contains("__xx__"))
             {
-                var index = impName.IndexOf("__xx__"); //avoid aliasing with funcs with x___y names
-                v1Name = impName.Substring(0, index);
-                v2Name = impName.Substring(index + 6);
-                var indexPointV1Name = v1Name.IndexOf(".");
-                var indexPointV2Name = v2Name.IndexOf(".");
-                v1Name = v1Name.Substring(0, indexPointV1Name);
-                v2Name = v2Name.Substring(0, indexPointV2Name);
+                var parts = impName.Split("__xx__");
+                v1Name = parts[0].Split('.')[0];
+                v2Name = parts[1].Split('.')[0];
             }
             else
             {

--- a/Sources/SymDiff/source/Config.cs
+++ b/Sources/SymDiff/source/Config.cs
@@ -235,7 +235,7 @@ namespace SDiff
     public void AddProcedure(Duple<HDuple<string>, ParamMap> mapping)
     {
       if (procMap.Exists(p => p.fst.fst.Equals(mapping.fst.fst)))
-        throw new Exception($"{mapping.fst.fst} already exists in config.");
+        throw new ArgumentException($"{mapping.fst.fst} already exists in config.");
       procMap.Add(mapping);
     }
 

--- a/Sources/SymDiff/source/Config.cs
+++ b/Sources/SymDiff/source/Config.cs
@@ -234,6 +234,8 @@ namespace SDiff
 
     public void AddProcedure(Duple<HDuple<string>, ParamMap> mapping)
     {
+      if (procMap.Exists(p => p.fst.fst.Equals(mapping.fst.fst)))
+        throw new Exception($"{mapping.fst.fst} already exists in config.");
       procMap.Add(mapping);
     }
 

--- a/Sources/SymDiff/source/Driver.cs
+++ b/Sources/SymDiff/source/Driver.cs
@@ -1,15 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO;
 using Microsoft.Boogie;
-using Bpl = Microsoft.Boogie;
-using B = SDiff.Boogie;
-using SDiff.Boogie;
 using SymDiffUtils;
-using Util = SymDiffUtils.Util;
-
 
 // This is the main procedure
 
@@ -373,20 +366,36 @@ namespace SDiff
 
     public static int GuessConfig(string[] args)
     {
+        string
+            first = args[0],
+            second = args[1];
+
+        Config config;
+        try
+        {
+            config = GuessConfig(first, second);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return 1;
+        }
+
+        Console.WriteLine(config.ToString());
+        return 0;
+    }
+    
+    public static Config GuessConfig(string first, string second)
+    {
         string boogieOptions = Options.BoogieUserOpts;
         //Log.Out(Log.Normal, "Initializing Boogie");
         if (SDiff.Boogie.Process.InitializeBoogie(boogieOptions))
-            return 1;
-
-
-        string
-          first = args[0],
-          second = args[1];
+            throw new Exception("Could not initialize Boogie during config generation.");
 
         // First program
         Program p = BoogieUtils.ParseProgram(first);
         if (p == null)
-            return 1;
+            throw new Exception("Could not parse the first program during config generation.");
 
         BoogieUtils.ResolveProgram(p, first, BoogieUtils.BoogieOptions);
         BoogieUtils.TypecheckProgram(p, first, BoogieUtils.BoogieOptions);
@@ -394,7 +403,7 @@ namespace SDiff
         // Second program
         Program q = BoogieUtils.ParseProgram(second);
         if (q == null)
-            return 1;
+            throw new Exception("Could not parse the second program during config generation.");
 
         BoogieUtils.ResolveProgram(q, second, BoogieUtils.BoogieOptions);
         BoogieUtils.TypecheckProgram(q, second, BoogieUtils.BoogieOptions);
@@ -500,8 +509,7 @@ namespace SDiff
                 config.AddType(new HDuple<string>(first + typesyn.Name, second + typesyn.Name));
         }
 
-        Console.WriteLine(config.ToString());
-        return 0;
+        return config;
     }
 
     public static BigBlock BlockToBigBlock(Block b)

--- a/Sources/SymDiff/source/LiveVariablesAnalysis.cs
+++ b/Sources/SymDiff/source/LiveVariablesAnalysis.cs
@@ -1,0 +1,227 @@
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.Boogie;
+using Microsoft.Boogie.GraphUtil;
+
+namespace SymDiff.source;
+
+public class LiveVariableAnalysis
+{
+  private CoreOptions options;
+
+  public LiveVariableAnalysis(CoreOptions options)
+  {
+    this.options = options;
+  }
+
+  public static void ClearLiveVariables(Implementation impl)
+  {
+    Contract.Requires(impl != null);
+    foreach (Block /*!*/ block in impl.Blocks)
+    {
+      Contract.Assert(block != null);
+      block.liveVarsBefore = null;
+    }
+  }
+
+  public void ComputeLiveVariables(Implementation impl, HashSet<GlobalVariable> globals)
+  {
+    Contract.Requires(impl != null);
+    Microsoft.Boogie.Helpers.ExtraTraceInformation(options, "Starting live variable analysis");
+    Graph<Block> dag = Program.GraphFromBlocks(impl.Blocks, false);
+    IEnumerable<Block> sortedNodes;
+
+    sortedNodes = dag.TopologicalSort(true);
+
+    foreach (Block /*!*/ block in sortedNodes)
+    {
+      Contract.Assert(block != null);
+      HashSet<Variable /*!*/> /*!*/
+        liveVarsAfter = new HashSet<Variable /*!*/>();
+
+      globals.ForEach(v => liveVarsAfter.Add(v));
+      // Add output parameters as always live
+      foreach (Variable v in impl.OutParams)
+      {
+        Contract.Assert(v != null);
+        liveVarsAfter.Add(v);
+      }
+
+      // The injected assumption variables should always be considered to be live.
+      foreach (var v in impl.InjectedAssumptionVariables.Concat(impl.DoomedInjectedAssumptionVariables))
+      {
+        liveVarsAfter.Add(v);
+      }
+
+      if (block.TransferCmd is GotoCmd)
+      {
+        GotoCmd gotoCmd = (GotoCmd) block.TransferCmd;
+        if (gotoCmd.labelTargets != null)
+        {
+          foreach (Block /*!*/ succ in gotoCmd.labelTargets)
+          {
+            Contract.Assert(succ != null);
+            Contract.Assert(succ.liveVarsBefore != null);
+            liveVarsAfter.UnionWith(succ.liveVarsBefore);
+          }
+        }
+      }
+
+      List<Cmd> cmds = block.Cmds;
+      int len = cmds.Count;
+      for (int i = len - 1; i >= 0; i--)
+      {
+        if (cmds[i] is CallCmd)
+        {
+          Procedure /*!*/
+            proc = cce.NonNull(cce.NonNull((CallCmd /*!*/) cmds[i]).Proc);
+          if (InterProcGenKill.HasSummary(proc.Name)) // TODO: this is always false! InterProcGenKill.ComputeLiveVars is never called.
+          {
+            liveVarsAfter =
+              InterProcGenKill.PropagateLiveVarsAcrossCall(options, cce.NonNull((CallCmd /*!*/) cmds[i]), liveVarsAfter);
+            continue;
+          }
+        }
+
+        Propagate(cmds[i], liveVarsAfter);
+      }
+
+      block.liveVarsBefore = liveVarsAfter;
+    }
+  }
+
+  // perform in place update of liveSet
+  public void Propagate(Cmd cmd, HashSet<Variable /*!*/> /*!*/ liveSet)
+  {
+    Contract.Requires(cmd != null);
+    Contract.Requires(cce.NonNullElements(liveSet));
+    if (cmd is AssignCmd)
+    {
+      AssignCmd /*!*/
+        assignCmd = (AssignCmd) cce.NonNull(cmd);
+      // I must first iterate over all the targets and remove the live ones.
+      // After the removals are done, I must add the variables referred on 
+      // the right side of the removed targets
+
+      AssignCmd simpleAssignCmd = assignCmd.AsSimpleAssignCmd;
+      HashSet<int> indexSet = new HashSet<int>();
+      int index = 0;
+      foreach (AssignLhs /*!*/ lhs in simpleAssignCmd.Lhss)
+      {
+        Contract.Assert(lhs != null);
+        SimpleAssignLhs salhs = lhs as SimpleAssignLhs;
+        Contract.Assert(salhs != null);
+        Variable var = salhs.DeepAssignedVariable;
+        if (var != null && liveSet.Contains(var))
+        {
+          indexSet.Add(index);
+          liveSet.Remove(var);
+        }
+
+        index++;
+      }
+
+      index = 0;
+      foreach (Expr /*!*/ expr in simpleAssignCmd.Rhss)
+      {
+        Contract.Assert(expr != null);
+        if (indexSet.Contains(index))
+        {
+          VariableCollector /*!*/
+            collector = new VariableCollector();
+          collector.Visit(expr);
+          liveSet.UnionWith(collector.usedVars);
+        }
+
+        index++;
+      }
+    }
+    else if (cmd is HavocCmd)
+    {
+      HavocCmd /*!*/
+        havocCmd = (HavocCmd) cmd;
+      foreach (IdentifierExpr /*!*/ expr in havocCmd.Vars)
+      {
+        Contract.Assert(expr != null);
+        if (expr.Decl != null && !(QKeyValue.FindBoolAttribute(expr.Decl.Attributes, "assumption") &&
+                                   expr.Decl.Name.StartsWith("a##cached##")))
+        {
+          liveSet.Remove(expr.Decl);
+        }
+      }
+    }
+    else if (cmd is PredicateCmd)
+    {
+      Contract.Assert((cmd is AssertCmd || cmd is AssumeCmd));
+      PredicateCmd /*!*/
+        predicateCmd = (PredicateCmd) cce.NonNull(cmd);
+      if (predicateCmd.Expr is LiteralExpr)
+      {
+        LiteralExpr le = (LiteralExpr) predicateCmd.Expr;
+        if (le.IsFalse)
+        {
+          liveSet.Clear();
+        }
+      }
+      else
+      {
+        VariableCollector /*!*/
+          collector = new VariableCollector();
+        collector.Visit(predicateCmd.Expr);
+        liveSet.UnionWith(collector.usedVars);
+      }
+    }
+    else if (cmd is CommentCmd)
+    {
+      // comments are just for debugging and don't affect verification
+    }
+    else if (cmd is CallCmd)
+    { // a CallCmd is also a SugaredCmd, but simpler to handle here
+      CallCmd /*!*/
+        callCmd = (CallCmd)cce.NonNull(cmd);
+      var outVars = callCmd.Outs.Select(v => v.Decl);
+      var isLive = outVars.Any(liveSet.Contains);
+      liveSet.RemoveWhere(outVars.Contains);
+
+      foreach (var expr in callCmd.Ins)
+      {
+        VariableCollector /*!*/
+          collector = new VariableCollector();
+        collector.Visit(expr);
+        liveSet.UnionWith(collector.usedVars);
+      }
+    }
+    else if (cmd is SugaredCmd)
+    {
+      SugaredCmd /*!*/
+        sugCmd = (SugaredCmd) cce.NonNull(cmd);
+      Propagate(sugCmd.GetDesugaring(options), liveSet);
+    }
+    else if (cmd is StateCmd)
+    {
+      StateCmd /*!*/
+        stCmd = (StateCmd) cce.NonNull(cmd);
+      List<Cmd> /*!*/
+        cmds = cce.NonNull(stCmd.Cmds);
+      int len = cmds.Count;
+      for (int i = len - 1; i >= 0; i--)
+      {
+        Propagate(cmds[i], liveSet);
+      }
+
+      foreach (Variable /*!*/ v in stCmd.Locals)
+      {
+        Contract.Assert(v != null);
+        liveSet.Remove(v);
+      }
+    }
+    else
+    {
+      {
+        Contract.Assert(false);
+        throw new cce.UnreachableException();
+      }
+    }
+  }
+}

--- a/Sources/SymDiff/source/LoopExtractor.cs
+++ b/Sources/SymDiff/source/LoopExtractor.cs
@@ -1,0 +1,676 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.Boogie;
+using Microsoft.Boogie.GraphUtil;
+using Set = Microsoft.Boogie.GSet<object>;
+
+namespace SymDiff.source;
+
+/// <summary>
+/// A copy of Boogie.LoopExtractor.
+/// </summary>
+public static class LoopExtractor {
+  public static (Dictionary<string, Dictionary<string, Block>> loops,
+                 HashSet<Implementation> procsWithIrreducibleLoops,
+                 Dictionary<Implementation, List<Implementation>> implToLoopImpls)
+    ExtractLoops(CoreOptions options, Program program, HashSet<Implementation> implsToIgnore = null)
+  {
+    var hasIrreducibleLoops = new HashSet<Implementation>();
+    List<Implementation /*!*/> /*!*/ loopImpls = new List<Implementation /*!*/>();
+    var implToLoopImpls = new Dictionary<Implementation, List<Implementation>>();
+    Dictionary<string, Dictionary<string, Block>> fullMap = new Dictionary<string, Dictionary<string, Block>>();
+    var globals = program.TopLevelDeclarations.OfType<GlobalVariable>().ToHashSet();
+    foreach (var impl in program.Implementations.Except(implsToIgnore ?? []))
+    {
+      if (impl.Blocks != null && impl.Blocks.Count > 0)
+      {
+        try
+        {
+          Graph<Block> g = program.ProcessLoops(options, impl);
+          var loopImplsForImpl = CreateProceduresForLoops(options, impl, g, loopImpls, fullMap, globals);
+          if (loopImplsForImpl.Count > 0)
+            implToLoopImpls.Add(impl, loopImplsForImpl);
+          impl.StructuredStmts = null; // TODO: A dirty fix as the structured statements are no longer up-to-date.
+        }
+        catch (Program.IrreducibleLoopException)
+        {
+          System.Diagnostics.Debug.Assert(!fullMap.ContainsKey(impl.Name));
+          fullMap[impl.Name] = null;
+          hasIrreducibleLoops.Add(impl);
+
+          if (options.ExtractLoopsUnrollIrreducible)
+          {
+            // statically unroll loops in this procedure
+
+            // First, build a map of the current blocks
+            var origBlocks = new Dictionary<string, Block>();
+            foreach (var blk in impl.Blocks)
+            {
+              origBlocks.Add(blk.Label, blk);
+            }
+
+            // unroll
+            Block start = impl.Blocks[0];
+            impl.Blocks = LoopUnroll.UnrollLoops(start, options.RecursionBound, false);
+
+            // Now construct the "map back" information
+            // Resulting block label -> original block
+            var blockMap = new Dictionary<string, Block>();
+            foreach (var blk in impl.Blocks)
+            {
+              var sl = LoopUnroll.sanitizeLabel(blk.Label);
+              if (sl == blk.Label)
+              {
+                blockMap.Add(blk.Label, blk);
+              }
+              else
+              {
+                Contract.Assert(origBlocks.ContainsKey(sl));
+                blockMap.Add(blk.Label, origBlocks[sl]);
+              }
+            }
+
+            fullMap[impl.Name] = blockMap;
+          }
+        }
+      }
+    }
+
+    foreach (Implementation /*!*/ loopImpl in loopImpls)
+    {
+      Contract.Assert(loopImpl != null);
+      program.AddTopLevelDeclaration(loopImpl);
+      program.AddTopLevelDeclaration(loopImpl.Proc);
+    }
+
+    return (fullMap, hasIrreducibleLoops, implToLoopImpls);
+  }
+
+  static List<Implementation> CreateProceduresForLoops(CoreOptions options, Implementation impl, Graph<Block /*!*/> /*!*/ g,
+    List<Implementation /*!*/> /*!*/ loopImpls,
+    Dictionary<string, Dictionary<string, Block>> fullMap,
+    HashSet<GlobalVariable> globals)
+  {
+    Contract.Requires(impl != null);
+    Contract.Requires(cce.NonNullElements(loopImpls));
+    // Enumerate the headers
+    // for each header h:
+    //   create implementation p_h with
+    //     inputs = inputs, outputs, and locals of impl
+    //     outputs = outputs and locals of impl
+    //     locals = empty set
+    //   add call o := p_h(i) at the beginning of the header block
+    //   break the back edges whose target is h
+    // Enumerate the headers again to create the bodies of p_h
+    // for each header h:
+    //   compute the loop corresponding to h
+    //   make copies of all blocks in the loop for h
+    //   delete all target edges that do not go to a block in the loop
+    //   create a new entry block and a new return block
+    //   add edges from entry block to the loop header and the return block
+    //   add calls o := p_h(i) at the end of the blocks that are sources of back edges
+    foreach (Block block in impl.Blocks)
+    {
+      AddToFullMap(fullMap, impl.Name, block.Label, block);
+    }
+
+    bool detLoopExtract = options.DeterministicExtractLoops;
+
+    Dictionary<Block /*!*/, List<Variable> /*!*/> /*!*/
+      loopHeaderToInputs = new Dictionary<Block /*!*/, List<Variable> /*!*/>();
+    Dictionary<Block /*!*/, List<Variable> /*!*/> /*!*/
+      loopHeaderToOutputs = new Dictionary<Block /*!*/, List<Variable> /*!*/>();
+    Dictionary<Block /*!*/, Dictionary<Variable, Expr> /*!*/> /*!*/
+      loopHeaderToSubstMap = new Dictionary<Block /*!*/, Dictionary<Variable, Expr> /*!*/>();
+    Dictionary<Block /*!*/, LoopProcedure /*!*/> /*!*/
+      loopHeaderToLoopProc = new Dictionary<Block /*!*/, LoopProcedure /*!*/>();
+    Dictionary<Block /*!*/, CallCmd /*!*/> /*!*/
+      loopHeaderToCallCmd1 = new Dictionary<Block /*!*/, CallCmd /*!*/>();
+    Dictionary<Block, CallCmd> loopHeaderToCallCmd2 = new Dictionary<Block, CallCmd>();
+    Dictionary<Block, AssignCmd> loopHeaderToAssignCmd = new Dictionary<Block, AssignCmd>();
+    Dictionary<Block, List<Variable>> loopHeaderToLoopProcLocalVars = new Dictionary<Block, List<Variable>>();
+    List<Implementation> loopImplsForThisImpl = new List<Implementation>();
+    
+    // Create a 1-unrolled implementation and apply live-variable analysis.
+    // Unrolling is needed for ComputeLiveVariables to work.
+    var unrolledBlocks = LoopUnroll.UnrollLoops(impl.Blocks[0], 1, false);
+    var unrolledImpl = new Implementation(Token.NoToken, impl.Name + "unrolled", impl.TypeParameters,
+      impl.InParams, impl.OutParams, impl.LocVars, unrolledBlocks);
+    new LiveVariableAnalysis(options).ComputeLiveVariables(unrolledImpl, globals);
+    
+    foreach (Block /*!*/ header in g.Headers)
+    {
+      Contract.Assert(header != null);
+      Contract.Assert(header != null);
+      List<Variable> inputs = new List<Variable>();
+      List<Variable> outputs = new List<Variable>();
+      List<Expr> callInputs1 = new List<Expr>();
+      List<IdentifierExpr> callOutputs1 = new List<IdentifierExpr>();
+      List<Expr> callInputs2 = new List<Expr>();
+      List<IdentifierExpr> callOutputs2 = new List<IdentifierExpr>();
+      List<AssignLhs> lhss = new List<AssignLhs>();
+      List<Expr> rhss = new List<Expr>();
+      Dictionary<Variable, Expr> substMap = new Dictionary<Variable, Expr>(); // Variable -> IdentifierExpr
+      var variablesToDeclareInLoopImpl = new List<Variable>();
+
+      List<Variable> /*!*/
+        targets = new List<Variable>();
+      HashSet<Variable> footprint = new HashSet<Variable>();
+
+      foreach (Block /*!*/ b in g.BackEdgeNodes(header))
+      {
+        Contract.Assert(b != null);
+        HashSet<Block> immSuccBlks = new HashSet<Block>();
+        if (detLoopExtract)
+        {
+          //Need to get the blocks that exit the loop, as we need to add them to targets and footprint
+          immSuccBlks = GetBreakBlocksOfLoop(options, header, b, g);
+        }
+
+        foreach (Block /*!*/ block in g.NaturalLoops(header, b).Union(immSuccBlks))
+        {
+          Contract.Assert(block != null);
+          foreach (Cmd /*!*/ cmd in block.Cmds)
+          {
+            Contract.Assert(cmd != null);
+            cmd.AddAssignedVariables(targets);
+
+            VariableCollector c = new VariableCollector();
+            c.Visit(cmd);
+            footprint.UnionWith(c.usedVars);
+          }
+        }
+      }
+
+      List<IdentifierExpr> /*!*/
+        globalMods = new List<IdentifierExpr>();
+      Set targetSet = new Set();
+      foreach (Variable /*!*/ v in targets)
+      {
+        Contract.Assert(v != null);
+        if (targetSet.Contains(v))
+        {
+          continue;
+        }
+
+        targetSet.Add(v);
+        if (v is GlobalVariable)
+        {
+          globalMods.Add(new IdentifierExpr(Token.NoToken, v));
+        }
+      }
+
+      foreach (Variable v in impl.InParams.OrderBy(variable => variable.Name))
+      {
+        Contract.Assert(v != null);
+        if (!footprint.Contains(v))
+        {
+          continue;
+        }
+
+        callInputs1.Add(new IdentifierExpr(Token.NoToken, v));
+        Formal f = new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "in_" + inputs.Count, v.TypedIdent.Type), true);
+        inputs.Add(f);
+        callInputs2.Add(new IdentifierExpr(Token.NoToken, f));
+        substMap[v] = new IdentifierExpr(Token.NoToken, f);
+      }
+
+      // Pass only live variables as argument to the extracted procedure.
+      var liveVarsBeforeHeader =
+        unrolledBlocks.FirstOrDefault(blk => blk.Label.Equals(header.Label + "#1"))?.liveVarsBefore.ToList() ?? footprint.ToList();
+      
+      foreach (Variable v in impl.OutParams.OrderBy(variable => variable.Name))
+      {
+        Contract.Assert(v != null);
+        if (!footprint.Contains(v))
+        {
+          continue;
+        }
+
+        // Variables that are in the footprint but are not live are loop-local,
+        // so we still need to declare these in the extracted implementation.
+        if (!liveVarsBeforeHeader.Contains(v))
+        {
+          variablesToDeclareInLoopImpl.Add(v);
+          continue;
+        }
+
+        callInputs1.Add(new IdentifierExpr(Token.NoToken, v));
+        Formal f1 = new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "in_" + inputs.Count, v.TypedIdent.Type), true);
+        inputs.Add(f1);
+        if (targetSet.Contains(v))
+        {
+          callOutputs1.Add(new IdentifierExpr(Token.NoToken, v));
+          Formal f2 = new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "out_" + outputs.Count, v.TypedIdent.Type),
+            false);
+          outputs.Add(f2);
+          callInputs2.Add(new IdentifierExpr(Token.NoToken, f2));
+          callOutputs2.Add(new IdentifierExpr(Token.NoToken, f2));
+          lhss.Add(new SimpleAssignLhs(Token.NoToken, new IdentifierExpr(Token.NoToken, f2)));
+          rhss.Add(new IdentifierExpr(Token.NoToken, f1));
+          substMap[v] = new IdentifierExpr(Token.NoToken, f2);
+        }
+        else
+        {
+          callInputs2.Add(new IdentifierExpr(Token.NoToken, f1));
+          substMap[v] = new IdentifierExpr(Token.NoToken, f1);
+        }
+      }
+
+      foreach (Variable v in impl.LocVars.OrderBy(variable => variable.Name))
+      {
+        Contract.Assert(v != null);
+        if (!footprint.Contains(v))
+        {
+          continue;
+        }
+
+        // Variables that are in the footprint but are not live are loop-local,
+        // so we still need to declare these in the extracted implementation.
+        if (!liveVarsBeforeHeader.Contains(v))
+        {
+          variablesToDeclareInLoopImpl.Add(v);
+          continue;
+        }
+
+        callInputs1.Add(new IdentifierExpr(Token.NoToken, v));
+        Formal f1 = new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "in_" + inputs.Count, v.TypedIdent.Type), true);
+        inputs.Add(f1);
+        if (targetSet.Contains(v))
+        {
+          callOutputs1.Add(new IdentifierExpr(Token.NoToken, v));
+          Formal f2 = new Formal(Token.NoToken, new TypedIdent(Token.NoToken, "out_" + outputs.Count, v.TypedIdent.Type),
+            false);
+          outputs.Add(f2);
+          callInputs2.Add(new IdentifierExpr(Token.NoToken, f2));
+          callOutputs2.Add(new IdentifierExpr(Token.NoToken, f2));
+          lhss.Add(new SimpleAssignLhs(Token.NoToken, new IdentifierExpr(Token.NoToken, f2)));
+          rhss.Add(new IdentifierExpr(Token.NoToken, f1));
+          substMap[v] = new IdentifierExpr(Token.NoToken, f2);
+        }
+        else
+        {
+          callInputs2.Add(new IdentifierExpr(Token.NoToken, f1));
+          substMap[v] = new IdentifierExpr(Token.NoToken, f1);
+        }
+      }
+
+      loopHeaderToLoopProcLocalVars[header] = variablesToDeclareInLoopImpl;
+      loopHeaderToInputs[header] = inputs;
+      loopHeaderToOutputs[header] = outputs;
+      loopHeaderToSubstMap[header] = substMap;
+      LoopProcedure loopProc = new LoopProcedure(impl, header, inputs, outputs, globalMods);
+      loopHeaderToLoopProc[header] = loopProc;
+
+      CallCmd callCmd1 = new CallCmd(Token.NoToken, loopProc.Name, callInputs1, callOutputs1);
+      callCmd1.Proc = loopProc;
+      loopHeaderToCallCmd1[header] = callCmd1;
+
+      CallCmd callCmd2 = new CallCmd(Token.NoToken, loopProc.Name, callInputs2, callOutputs2);
+      callCmd2.Proc = loopProc;
+      loopHeaderToCallCmd2[header] = callCmd2;
+
+      Debug.Assert(lhss.Count == rhss.Count);
+      if (lhss.Count > 0)
+      {
+        AssignCmd assignCmd = new AssignCmd(Token.NoToken, lhss, rhss);
+        loopHeaderToAssignCmd[header] = assignCmd;
+      }
+    }
+
+    // Keep track of the new blocks created: maps a header node to the
+    // header_last block that was created because of splitting header.
+    Dictionary<Block, Block> newBlocksCreated = new Dictionary<Block, Block>();
+
+    bool headRecursion = false; // testing an option to put recursive call before loop body
+
+    IEnumerable<Block> sortedHeaders = g.SortHeadersByDominance();
+    foreach (Block /*!*/ header in sortedHeaders)
+    {
+      Contract.Assert(header != null);
+      LoopProcedure loopProc = loopHeaderToLoopProc[header];
+      Dictionary<Block, Block> blockMap = new Dictionary<Block, Block>();
+      HashSet<string> dummyBlocks = new HashSet<string>();
+
+      var subst = Substituter.SubstitutionFromDictionary(loopHeaderToSubstMap[header]); // fix me
+      List<Variable> inputs = loopHeaderToInputs[header];
+      List<Variable> outputs = loopHeaderToOutputs[header];
+      int si_unique_loc = 1; // Added by AL: to distinguish the back edges
+      foreach (Block /*!*/ source in g.BackEdgeNodes(header))
+      {
+        Contract.Assert(source != null);
+        foreach (Block /*!*/ block in g.NaturalLoops(header, source))
+        {
+          Contract.Assert(block != null);
+          if (blockMap.ContainsKey(block))
+          {
+            continue;
+          }
+
+          Block newBlock = new Block();
+          newBlock.Label = block.Label;
+          if (headRecursion && block == header)
+          {
+            CallCmd callCmd = (CallCmd) (loopHeaderToCallCmd2[header]).Clone();
+            addUniqueCallAttr(si_unique_loc, callCmd);
+            si_unique_loc++;
+            newBlock.Cmds.Add(callCmd); // add the recursive call at head of loop
+            var rest = Substituter.Apply(subst, block.Cmds);
+            newBlock.Cmds.AddRange(rest);
+          }
+          else
+          {
+            newBlock.Cmds = Substituter.Apply(subst, block.Cmds);
+          }
+
+          blockMap[block] = newBlock;
+          if (newBlocksCreated.ContainsKey(block))
+          {
+            Block newBlock2 = new Block();
+            newBlock2.Label = newBlocksCreated[block].Label;
+            newBlock2.Cmds = Substituter.Apply(subst, newBlocksCreated[block].Cmds);
+            blockMap[newBlocksCreated[block]] = newBlock2;
+          }
+
+          //for detLoopExtract, need the immediate successors even outside the loop
+          if (detLoopExtract)
+          {
+            GotoCmd auxGotoCmd = block.TransferCmd as GotoCmd;
+            Contract.Assert(auxGotoCmd != null && auxGotoCmd.labelNames != null &&
+                            auxGotoCmd.labelTargets != null && auxGotoCmd.labelTargets.Count >= 1);
+            //BUGFIX on 10/26/15: this contains nodes present in NaturalLoops for a different backedgenode
+            var loopNodes = GetBlocksInAllNaturalLoops(options, header, g); //var loopNodes = g.NaturalLoops(header, source);
+            foreach (var bl in auxGotoCmd.labelTargets)
+            {
+              if (g.Nodes.Contains(bl) && //newly created blocks are not present in NaturalLoop(header, xx, g)
+                  !loopNodes.Contains(bl))
+              {
+                Block auxNewBlock = new Block();
+                auxNewBlock.Label = bl.Label;
+                //these blocks may have read/write locals that are not present in naturalLoops
+                //we need to capture these variables
+                auxNewBlock.Cmds = Substituter.Apply(subst, bl.Cmds);
+                //add restoration code for such blocks
+                if (loopHeaderToAssignCmd.ContainsKey(header))
+                {
+                  AssignCmd assignCmd = loopHeaderToAssignCmd[header];
+                  auxNewBlock.Cmds.Add(assignCmd);
+                }
+
+                List<AssignLhs> lhsg = new List<AssignLhs>();
+                List<IdentifierExpr> /*!*/
+                  globalsMods = loopHeaderToLoopProc[header].Modifies;
+                foreach (IdentifierExpr gl in globalsMods)
+                {
+                  lhsg.Add(new SimpleAssignLhs(Token.NoToken, gl));
+                }
+
+                List<Expr> rhsg = new List<Expr>();
+                foreach (IdentifierExpr gl in globalsMods)
+                {
+                  rhsg.Add(new OldExpr(Token.NoToken, gl));
+                }
+
+                if (lhsg.Count != 0)
+                {
+                  AssignCmd globalAssignCmd = new AssignCmd(Token.NoToken, lhsg, rhsg);
+                  auxNewBlock.Cmds.Add(globalAssignCmd);
+                }
+
+                blockMap[(Block) bl] = auxNewBlock;
+              }
+            }
+          }
+        }
+
+        List<Cmd> cmdSeq;
+        if (headRecursion)
+        {
+          cmdSeq = new List<Cmd>();
+        }
+        else
+        {
+          CallCmd callCmd = (CallCmd) (loopHeaderToCallCmd2[header]).Clone();
+          addUniqueCallAttr(si_unique_loc, callCmd);
+          si_unique_loc++;
+          cmdSeq = new List<Cmd> {callCmd};
+        }
+
+        Block /*!*/
+          block1 = new Block(Token.NoToken, source.Label + "_dummy",
+            new List<Cmd> {new AssumeCmd(Token.NoToken, Expr.False)}, new ReturnCmd(Token.NoToken));
+        Block /*!*/
+          block2 = new Block(Token.NoToken, block1.Label,
+            cmdSeq, new ReturnCmd(Token.NoToken));
+        impl.Blocks.Add(block1);
+        dummyBlocks.Add(block1.Label);
+
+        GotoCmd gotoCmd = source.TransferCmd as GotoCmd;
+        Contract.Assert(gotoCmd != null && gotoCmd.labelNames != null && gotoCmd.labelTargets != null &&
+                        gotoCmd.labelTargets.Count >= 1);
+        List<string> /*!*/
+          newLabels = new List<String>();
+        List<Block> /*!*/
+          newTargets = new List<Block>();
+        for (int i = 0; i < gotoCmd.labelTargets.Count; i++)
+        {
+          if (gotoCmd.labelTargets[i] == header)
+          {
+            continue;
+          }
+
+          newTargets.Add(gotoCmd.labelTargets[i]);
+          newLabels.Add(gotoCmd.labelNames[i]);
+        }
+
+        newTargets.Add(block1);
+        newLabels.Add(block1.Label);
+        gotoCmd.labelNames = newLabels;
+        gotoCmd.labelTargets = newTargets;
+        blockMap[block1] = block2;
+      }
+
+      List<Block /*!*/> /*!*/
+        blocks = new List<Block /*!*/>();
+      Block exit = new Block(Token.NoToken, "exit", new List<Cmd>(), new ReturnCmd(Token.NoToken));
+      GotoCmd cmd = new GotoCmd(Token.NoToken,
+        new List<String> {cce.NonNull(blockMap[header]).Label, exit.Label},
+        new List<Block> {blockMap[header], exit});
+
+      if (detLoopExtract) //cutting the non-determinism
+      {
+        cmd = new GotoCmd(Token.NoToken,
+          new List<String> {cce.NonNull(blockMap[header]).Label},
+          new List<Block> {blockMap[header]});
+      }
+
+      Block entry;
+      List<Cmd> initCmds = new List<Cmd>();
+      if (loopHeaderToAssignCmd.ContainsKey(header))
+      {
+        AssignCmd assignCmd = loopHeaderToAssignCmd[header];
+        initCmds.Add(assignCmd);
+      }
+
+      entry = new Block(Token.NoToken, "entry", initCmds, cmd);
+      blocks.Add(entry);
+
+      foreach (Block /*!*/ block in blockMap.Keys)
+      {
+        Contract.Assert(block != null);
+        Block /*!*/
+          newBlock = cce.NonNull(blockMap[block]);
+        GotoCmd gotoCmd = block.TransferCmd as GotoCmd;
+        if (gotoCmd == null)
+        {
+          newBlock.TransferCmd = new ReturnCmd(Token.NoToken);
+        }
+        else
+        {
+          Contract.Assume(gotoCmd.labelNames != null && gotoCmd.labelTargets != null);
+          List<String> newLabels = new List<String>();
+          List<Block> newTargets = new List<Block>();
+          for (int i = 0; i < gotoCmd.labelTargets.Count; i++)
+          {
+            Block target = gotoCmd.labelTargets[i];
+            if (blockMap.ContainsKey(target))
+            {
+              newLabels.Add(gotoCmd.labelNames[i]);
+              newTargets.Add(blockMap[target]);
+            }
+          }
+
+          if (newTargets.Count == 0)
+          {
+            if (!detLoopExtract)
+            {
+              newBlock.Cmds.Add(new AssumeCmd(Token.NoToken, Expr.False));
+            }
+
+            newBlock.TransferCmd = new ReturnCmd(Token.NoToken);
+          }
+          else
+          {
+            newBlock.TransferCmd = new GotoCmd(Token.NoToken, newLabels, newTargets);
+          }
+        }
+
+        blocks.Add(newBlock);
+      }
+
+      blocks.Add(exit);
+      Implementation loopImpl =
+        new Implementation(Token.NoToken, loopProc.Name,
+          new List<TypeVariable>(), inputs, outputs, loopHeaderToLoopProcLocalVars[header], blocks);
+      loopImpl.Proc = loopProc;
+      loopImpls.Add(loopImpl);
+      loopImplsForThisImpl.Add(loopImpl);
+
+      // Make a (shallow) copy of the header before splitting it
+      Block origHeader = new Block(header.tok, header.Label, header.Cmds, header.TransferCmd);
+
+      // Finally, add call to the loop in the containing procedure
+      string lastIterBlockName = header.Label + "_last";
+      //Block lastIterBlock = new Block(Token.NoToken, lastIterBlockName, header.Cmds, header.TransferCmd);
+      Block lastIterBlock = new Block(Token.NoToken, lastIterBlockName, header.Cmds, header.TransferCmd);
+      newBlocksCreated[header] = lastIterBlock;
+      header.Cmds = new List<Cmd> {loopHeaderToCallCmd1[header]};
+      header.TransferCmd = new GotoCmd(Token.NoToken, new List<String> {lastIterBlockName},
+        new List<Block> {lastIterBlock});
+      impl.Blocks.Add(lastIterBlock);
+      blockMap[origHeader] = blockMap[header];
+      blockMap.Remove(header);
+
+      Contract.Assert(fullMap[impl.Name][header.Label] == header);
+      fullMap[impl.Name][header.Label] = origHeader;
+
+      foreach (Block block in blockMap.Keys)
+      {
+        // Don't add dummy blocks to the map
+        if (dummyBlocks.Contains(blockMap[block].Label))
+        {
+          continue;
+        }
+
+        // Following two statements are for nested loops: compose map
+        if (!fullMap[impl.Name].ContainsKey(block.Label))
+        {
+          continue;
+        }
+
+        var target = fullMap[impl.Name][block.Label];
+
+        AddToFullMap(fullMap, loopProc.Name, blockMap[block].Label, target);
+      }
+
+      fullMap[impl.Name].Remove(header.Label);
+      fullMap[impl.Name][lastIterBlockName] = origHeader;
+    }
+    return loopImplsForThisImpl;
+  }
+
+  private static void addUniqueCallAttr(int val, CallCmd cmd)
+  {
+    var a = new List<object>();
+    a.Add(new LiteralExpr(Token.NoToken, Microsoft.BaseTypes.BigNum.FromInt(val)));
+
+    cmd.Attributes = new QKeyValue(Token.NoToken, "si_unique_call", a, cmd.Attributes);
+  }
+
+  private static void AddToFullMap(Dictionary<string, Dictionary<string, Block>> fullMap, string procName, string blockName,
+    Block block)
+  {
+    if (!fullMap.ContainsKey(procName))
+    {
+      fullMap[procName] = new Dictionary<string, Block>();
+    }
+
+    fullMap[procName][blockName] = block;
+  }
+
+  private static HashSet<Block> GetBlocksInAllNaturalLoops(CoreOptions options, Block header, Graph<Block /*!*/> /*!*/ g)
+  {
+    Contract.Assert(options.DeterministicExtractLoops,
+      "Can only be called with /deterministicExtractLoops option");
+    var allBlocksInNaturalLoops = new HashSet<Block>();
+    foreach (Block /*!*/ source in g.BackEdgeNodes(header))
+    {
+      Contract.Assert(source != null);
+      g.NaturalLoops(header, source).ToList().ForEach(b => allBlocksInNaturalLoops.Add(b));
+    }
+
+    return allBlocksInNaturalLoops;
+  }
+
+
+  /// <summary>
+  /// Finds blocks that break out of a loop in NaturalLoops(header, backEdgeNode)
+  /// </summary>
+  /// <param name="header"></param>
+  /// <param name="backEdgeNode"></param>
+  /// <returns></returns>
+  private static HashSet<Block> GetBreakBlocksOfLoop(CoreOptions options, Block header, Block backEdgeNode, Graph<Block /*!*/> /*!*/ g)
+  {
+    Contract.Assert(options.DeterministicExtractLoops,
+      "Can only be called with /deterministicExtractLoops option");
+    var immSuccBlks = new HashSet<Block>();
+    var loopBlocks = g.NaturalLoops(header, backEdgeNode);
+    foreach (Block /*!*/ block in loopBlocks)
+    {
+      Contract.Assert(block != null);
+      var auxCmd = block.TransferCmd as GotoCmd;
+      if (auxCmd == null)
+      {
+        continue;
+      }
+
+      foreach (var bl in auxCmd.labelTargets)
+      {
+        if (loopBlocks.Contains(bl))
+        {
+          continue;
+        }
+
+        immSuccBlks.Add(bl);
+      }
+    }
+
+    return immSuccBlks;
+  }
+
+  public static bool HasLoops(this Implementation impl, Program program, CoreOptions options)
+  {
+      try
+      {
+        var g = program.ProcessLoops(options, impl);
+        return g.Headers.Any();
+      }
+      catch (Program.IrreducibleLoopException)
+      {
+        return true;
+      }
+  }
+}

--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -62,6 +62,7 @@ namespace SDiff
         public static bool nonModularMode;
         public static bool checkAssertsOnly;
         public static bool noSyntacticCheck;
+        public static bool noLoopExtract;
 
         //mutual summaries
         public static bool mutualSummaryMode;
@@ -92,7 +93,7 @@ namespace SDiff
         public static int inlineAllRecursionDepth = 1;
         public static int Timeout = 200; //default timeout for each check
         public static int NumCex = -1; //-1 denotes find all cex
-        public static HashSet<string> syntacticEqProcs = new HashSet<string>();
+        public static Dictionary<string, string> syntacticEqProcs = new();
         public static string changeListFile = null;  //file containing change_list.txt
 
         public static bool StripContracts = true; //we currently have to strip contracts for correctness and (possibly) stability.

--- a/Sources/SymDiff/source/Transform.cs
+++ b/Sources/SymDiff/source/Transform.cs
@@ -326,10 +326,18 @@ namespace SDiff
       return new Duple<Procedure, Implementation>(eqProc, eqImp);
     }
 
+    private static string sanitize(string s)
+    { 
+      return s.Replace("$", "");
+    }
     public static string mkEqProcName(string p1, string p2)
     {
-        return "EQ_" + p1 + "__xx__" + p2;
-
+      var p1WithoutPrefix = p1.Split(".").Last();
+      var p2WithoutPrefix = p2.Split(".").Last();
+      if (p1WithoutPrefix.Equals(p2WithoutPrefix))
+        return "EQ_" + sanitize(p1WithoutPrefix);
+      else
+        return "EQ_" + sanitize(p1) + "__xx__" + sanitize(p2);
     }
 
     public static void NormalizeProcedures(Procedure d1, Implementation i1, List<Variable> g1,

--- a/Sources/SymDiffUtils/boogieUtils.cs
+++ b/Sources/SymDiffUtils/boogieUtils.cs
@@ -3,6 +3,7 @@ using Microsoft.Boogie.GraphUtil;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 
 namespace SymDiffUtils
@@ -58,8 +59,23 @@ namespace SymDiffUtils
 
         public static bool ResolveAndTypeCheckThrow(Program p, string filename, CommandLineOptions boogieOptions)
         {
-            if (ResolveAndTypeCheck(p, filename, boogieOptions))
-                throw new Exception("Program " + filename + " does not resolve/typecheck");
+            bool failed;
+            try
+            {
+                failed = ResolveAndTypeCheck(p, filename, boogieOptions);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                failed = true;
+            }
+
+            if (failed) {
+                var dumpFileName = filename.Replace(".bpl", "_dumped.bpl");
+                Util.DumpBplAST(p, dumpFileName);
+                throw new Exception("Program " + filename + " does not resolve/typecheck\n" +
+                                    "Output dumped to " + dumpFileName + "\n");
+            }
             return false;
         }
 


### PR DESCRIPTION
Adds block outlining and loop extraction to SymDiff.

### Block outlining
The idea of block outlining is to compute differing blocks in _similar_ implementations, outline/extract them as procedures in order to compare them compositionally. 

In the current version two implementations are _similar_ if their procedures are listed for comparison in the configuration file and if they have the same number of blocks and block edges in their implementation graphs.

The outlining is done at single-block granularity (i.e., one procedure is extracted per differing block). Blocks are not outlined if they contain `assume` statements over variables, as this might make the transformation unsound due to partial equivalence semantics.

### Loop extraction
Loop extraction is mostly carried over from Boogie and a live variable analysis is added to make the signatures less sensitive to changes in extracted loop bodies. The live variable analysis is also moved from Boogie, with changes to mark globals and return parameters as live at procedure exit. Ideally, these two classes should be moved back into Boogie and removed from SymDiff.

The reason for doing loop extraction and block outlining in SymDiff is that the user cannot be expected to provide a configuration for automatically extracted procedures. It is easier to extend the user-provided configuration with additional procedures using the information collected during extraction.

### Summary of all changes

- (Standard SymDiff) Outline/extract differing blocks in otherwise highly similar implementations as procedures when `-noSyn` option is not provided.
- (Standard SymDiff) Extract loops as recursive procedures when `-noLoopExtract` option is not provided. This is moved within SymDiff, as it makes it easier to pair extracted loop proecedures which the user cannot manually supply.
- (Standard SymDiff) Infer a config automatically when none is provided.
- (Standard SymDiff) Refactor `GuessConfig` to return a `Config` to support library calls. Original functionality is preserved with a wrapper.
- (Structural comparison) Make structural comparison less brittle. Order blocks and sequential blocks of assume statements prior to comparison.
- (Structural comparison) Provide an initial function mapping for comparison of function calls.
- (LoopExtractor) Return a dictionary of extracted loop procedures for every implementation with a loop.
- (LoopExtractor) New `HasLoops` extension method for Implementation.
- (Options) Change `syntacticEqProcs` from a set to a dictionary. This allows specifying structurally equivalent procedures with different names.
- (Misc) Shorten created equality procedure names when possible and eliminate `$` symbols.
- (Misc) Dump and print a path to intermediate Boogie programs when typechecking / resolution fails.