### PR TITLE
Better alignment of extracted loop procedure parameters

### DIFF
--- a/Sources/SymDiff/source/BiDictionary.cs
+++ b/Sources/SymDiff/source/BiDictionary.cs
@@ -58,13 +58,13 @@ public class BiDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>
         if (keyToValue.ContainsKey(key))
         {
             throw new ArgumentException($"The key already exists: ({key}, {keyToValue[key]})." +
-                                        $"Tried to add ({key}, {value})");
+                                        $" Tried to add ({key}, {value})");
         }
 
         if (valueToKey.ContainsKey(value))
         {
             throw new ArgumentException($"The value already exists: ({valueToKey[value]}, {value})." +
-                                        $"Tried to add ({key}, {value})");
+                                        $" Tried to add ({key}, {value})");
         }
 
         keyToValue[key] = value;

--- a/Sources/SymDiff/source/BiDictionary.cs
+++ b/Sources/SymDiff/source/BiDictionary.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace SymDiff.source;
+
+using System.Collections.Generic;
+
+/// <summary>
+/// A bijective (one-to-one) dictionary.
+/// </summary>
+public class BiDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+{
+    private Dictionary<TKey, TValue> keyToValue;
+    private Dictionary<TValue, TKey> valueToKey;
+
+    public BiDictionary()
+    {
+        keyToValue = new Dictionary<TKey, TValue>();
+        valueToKey = new Dictionary<TValue, TKey>();
+    }
+
+    public BiDictionary(BiDictionary<TKey, TValue> other)
+    {
+        keyToValue = new Dictionary<TKey, TValue>(other.keyToValue);
+        valueToKey = new Dictionary<TValue, TKey>(other.valueToKey);
+    }
+    
+    public BiDictionary(Dictionary<TKey, TValue> other)
+    {
+        keyToValue = new Dictionary<TKey, TValue>(other);
+        valueToKey = new Dictionary<TValue, TKey>();
+
+        if (other.Values.Distinct().Count() != other.Count)
+        {
+            throw new ArgumentException("Values must be unique for a bijective mapping.");
+        }
+
+        foreach (var pair in other)
+        {
+            valueToKey.Add(pair.Value, pair.Key);
+        }
+    }
+
+    public bool TryAdd(TKey key, TValue value)
+    {
+        if (keyToValue.ContainsKey(key) || valueToKey.ContainsKey(value))
+        {
+            return false;
+        }
+
+        Add(key, value);
+        return true;
+    }
+
+    public void Add(TKey key, TValue value)
+    {
+        if (keyToValue.ContainsKey(key))
+        {
+            throw new ArgumentException($"The key already exists: ({key}, {keyToValue[key]})." +
+                                        $"Tried to add ({key}, {value})");
+        }
+
+        if (valueToKey.ContainsKey(value))
+        {
+            throw new ArgumentException($"The value already exists: ({valueToKey[value]}, {value})." +
+                                        $"Tried to add ({key}, {value})");
+        }
+
+        keyToValue[key] = value;
+        valueToKey[value] = key;
+    }
+
+    /// <summary>
+    /// Returns true if either the key or the value is matched with a conflicting other.
+    /// Returns false if there is no conflict, or if the pair does not exist in the map.
+    /// </summary>
+    public bool HasConflict(TKey key, TValue value)
+    {
+        var hasKey = keyToValue.TryGetValue(key, out TValue existingValue);
+        var hasValue = valueToKey.TryGetValue(value, out TKey existingKey);
+
+        if (hasKey && !EqualityComparer<TValue>.Default.Equals(value, existingValue))
+        {
+            return true;
+        }
+
+        if (hasValue && !EqualityComparer<TKey>.Default.Equals(key, existingKey))
+        {
+            return true;
+        }
+
+        return false;
+    }
+    
+    /// <summary>
+    /// Update the map if the key/value does not exist with a conflicting
+    /// value/key. Returns false if there was a conflict, true otherwise.
+    /// </summary>
+    public bool TryAddIfNoConflict(TKey key, TValue value)
+    {
+        if (HasConflict(key, value))
+        {
+            return false;
+        }
+
+        // No conflict. The update might be redundant but it is safe.
+        keyToValue[key] = value;
+        valueToKey[value] = key;
+        return true;
+    }
+
+    public TValue GetValueByKey(TKey key)
+    {
+        if (!keyToValue.TryGetValue(key, out TValue value))
+        {
+            throw new KeyNotFoundException($"The given key '{key}' was not present in the dictionary.");
+        }
+        return value;
+    }
+
+    public TKey GetKeyByValue(TValue value)
+    {
+        if (!valueToKey.TryGetValue(value, out TKey key))
+        {
+            throw new KeyNotFoundException($"The given value '{value}' was not present in the dictionary.");
+        }
+        return key;
+    }
+
+    public bool TryGetValueByKey(TKey key, out TValue value)
+    {
+        return keyToValue.TryGetValue(key, out value);
+    }
+
+    public bool TryGetKeyByValue(TValue value, out TKey key)
+    {
+        return valueToKey.TryGetValue(value, out key);
+    }
+
+    public bool RemoveByKey(TKey key)
+    {
+        if (!keyToValue.TryGetValue(key, out var value))
+        {
+            return false;
+        }
+
+        keyToValue.Remove(key);
+        valueToKey.Remove(value);
+        return true;
+    }
+
+    public bool RemoveByValue(TValue value)
+    {
+        if (!valueToKey.TryGetValue(value, out var key))
+        {
+            return false;
+        }
+
+        valueToKey.Remove(value);
+        keyToValue.Remove(key);
+        return true;
+    }
+
+    public bool ContainsKey(TKey key)
+    {
+        return keyToValue.ContainsKey(key);
+    }
+
+    public bool ContainsValue(TValue value)
+    {
+        return valueToKey.ContainsKey(value);
+    }
+
+    public void Clear()
+    {
+        keyToValue.Clear();
+        valueToKey.Clear();
+    }
+    
+    public Dictionary<TKey, TValue>.KeyCollection Keys => keyToValue.Keys;
+    
+    public Dictionary<TKey, TValue>.ValueCollection Values => keyToValue.Values;
+
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
+    {
+        return keyToValue.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
+++ b/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
@@ -17,7 +17,7 @@ public static class BoogieStructuralComparisonManager
     /// </summary>
     public static bool EqualsStructural(this Implementation? thisImpl,
                                         Implementation? otherImpl,
-                                        ReadOnlyDictionary<string, string> functionMapping,
+                                        BiDictionary<string, string> functionMapping,
                                         out Dictionary<Procedure, Procedure> procedureMapping,
                                         out Dictionary<Variable, Variable> globalsMapping,
                                         out Dictionary<Variable, Variable> localsMapping)
@@ -25,19 +25,20 @@ public static class BoogieStructuralComparisonManager
         var implComparer = new ImplementationComparer(functionMapping);
         var res = implComparer.Compare(thisImpl, otherImpl);
 
-        procedureMapping = implComparer.ProcedureMapping;
-        globalsMapping = implComparer.GlobalVarMapping;
-        localsMapping = implComparer.LocalVarMapping;
+        procedureMapping = implComparer.ProcedureMapping.ToDictionary();
+        globalsMapping = implComparer.GlobalVarMapping.ToDictionary();
+        localsMapping = implComparer.LocalVarMapping.ToDictionary();
         return res;
     }
 }
 
-public class ImplementationComparer(ReadOnlyDictionary<string, string> functionMapping)
+public class ImplementationComparer(BiDictionary<string, string> functionMapping)
 {
-    public Dictionary<Variable, Variable> LocalVarMapping = new();
-    public Dictionary<Block, Block> BlockMapping = new();
-    public Dictionary<Variable, Variable> GlobalVarMapping = new();
-    public Dictionary<Procedure, Procedure> ProcedureMapping = new();
+    public BiDictionary<Variable, Variable> LocalVarMapping = new();
+    public BiDictionary<Block, Block> BlockMapping = new();
+    public BiDictionary<Variable, Variable> GlobalVarMapping = new();
+    public BiDictionary<Procedure, Procedure> ProcedureMapping = new();
+    private HashSet<Absy> alreadyMappedValues = new();
 
     public bool Compare(Implementation? implA, Implementation? implB)
     {
@@ -46,12 +47,19 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
                           || implA.InParams.Count != implB.InParams.Count
                           || implA.OutParams.Count != implB.OutParams.Count
                           || implA.Blocks.Count != implB.Blocks.Count)
+        {
             return false;
+        }
 
         // TODO: try to match the blocks in a better way, e.g., compute a graph isomorphism
         foreach (var (blk1, blk2) in implA.Blocks.OrderBy(b => b.Label)
-                                .Zip(implB.Blocks.OrderBy(b => b.Label)))
-            if (!Compare(blk1, blk2)) return false;
+                     .Zip(implB.Blocks.OrderBy(b => b.Label)))
+        {
+            if (!Compare(blk1, blk2))
+            {
+                return false;
+            }
+        }
 
         return true;
     }
@@ -60,25 +68,28 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
     {
         if (blockA.TransferCmd == null || blockB.TransferCmd == null ||
             blockA.TransferCmd.GetType() != blockB.TransferCmd.GetType())
+        {
             return false;
+        }
 
-        var localBlockMapping = new Dictionary<Block, Block>();
+        var localBlockMapping = new BiDictionary<Block, Block>(BlockMapping);
+
         if (blockA.TransferCmd is GotoCmd t1 &&
             blockB.TransferCmd is GotoCmd t2)
+        {
             foreach (var (blkTarget1, blkTarget2) in t1.labelTargets.Zip(t2.labelTargets))
             {
-                if (BlockMapping.TryGetValue(blkTarget1, out var mappedBlkTarget2))
+                if (!localBlockMapping.TryAddIfNoConflict(blkTarget1, blkTarget2))
                 {
-                    if (mappedBlkTarget2 != blkTarget2)
-                        return false;
-                    else
-                        localBlockMapping.Add(blkTarget1, blkTarget2);
+                    return false;
                 }
             }
+        }
 
         var i = 0;
         var j = 0;
-        while (i < blockA.Cmds.Count && j < blockB.Cmds.Count)
+        while (i < blockA.Cmds.Count &&
+               j < blockB.Cmds.Count)
         {
             if (IsIrrelevantCommand(blockA.Cmds[i]))
             {
@@ -101,16 +112,28 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
                     .Select(c => c as AssumeCmd)
                     .OrderBy(c => c!.Expr.ToString()).ToList();
                 if (assumesA.Count != assumesB.Count)
+                {
                     return false;
+                }
+
                 foreach (var (assm1, assm2) in assumesA.Zip(assumesB))
+                {
                     if (!Compare(assm1, assm2))
+                    {
                         return false;
+                    }
+                }
+
                 i += assumesA.Count;
                 j += assumesB.Count;
                 continue;
             }
+
             if (!Compare(blockA.Cmds[i], blockB.Cmds[j]))
+            {
                 return false;
+            }
+
             i++;
             j++;
         }
@@ -118,19 +141,25 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
         for (; i < blockA.Cmds.Count; ++i)
         {
             if (!IsIrrelevantCommand(blockA.Cmds[i]))
+            {
                 return false;
+            }
         }
         for (; j < blockB.Cmds.Count; ++j)
         {
             if (!IsIrrelevantCommand(blockB.Cmds[j]))
+            {
                 return false;
+            }
         }
 
-        // Update the mapping if there were no conflicts. The pair might already
-        // exist, so we use TryAdd. This is safe because we know from the earlier
-        // check that any existing value will not have a conflict.
+        // Update the mapping if there were no conflicts. Using TryAdd here is safe here
+        // because if the pair already exists it cannot be different due to the earlier check.
         foreach (var pair in localBlockMapping)
+        {
             BlockMapping.TryAdd(pair.Key, pair.Value);
+        }
+
         BlockMapping.TryAdd(blockA, blockB);
 
         return true;
@@ -138,7 +167,8 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
 
     private bool EqualsStructuralExpr(Expr exprA, Expr exprB)
     {
-        var combinedMapping = LocalVarMapping.Concat(GlobalVarMapping).ToDictionary();
+        var combinedMapping = new BiDictionary<Variable, Variable>(
+            LocalVarMapping.Concat(GlobalVarMapping).ToDictionary());
         var exprComparator = new ExprComparatorWithRenaming(combinedMapping, functionMapping);
         var res = exprComparator.Compare(exprA, exprB);
         if (!res) return false;
@@ -164,8 +194,16 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
     
     private bool Compare(Cmd? cmdA, Cmd? cmdB)
     {
-        if (cmdA == null || cmdB == null) return cmdA == cmdB;
-        if (cmdA.GetType() != cmdB.GetType()) return false;
+        if (cmdA == null || cmdB == null)
+        {
+            return cmdA == cmdB;
+        }
+
+        if (cmdA.GetType() != cmdB.GetType())
+        {
+            return false;
+        }
+
         return (cmdA, cmdB) switch
         {
             (AssertCmd a, AssertCmd b) => EqualsStructuralExpr(a.Expr, b.Expr),
@@ -180,20 +218,23 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
 
     private bool EqualsStructuralCall(CallCmd cmdA, CallCmd cmdB)
     {
-        var procA = cmdA.Proc;
-        if (ProcedureMapping.TryGetValue(procA, out var procB) && cmdB.Proc != procB)
+        if (ProcedureMapping.HasConflict(cmdA.Proc, cmdB.Proc))
+        {
             return false;
+        }
 
-        procB = cmdB.Proc;
-
-        if (procA.InParams.Count != procB.InParams.Count)
+        if (cmdA.Proc.InParams.Count != cmdB.Proc.InParams.Count)
+        {
             return false;
+        }
 
-        if (cmdA.Ins .Zip(cmdB.Ins) .Any(p => !EqualsStructuralExpr(p.First, p.Second)) ||
+        if (cmdA.Ins.Zip(cmdB.Ins).Any(p => !EqualsStructuralExpr(p.First, p.Second)) ||
             cmdA.Outs.Zip(cmdB.Outs).Any(p => !EqualsStructuralExpr(p.First, p.Second)))
+        {
             return false;
+        }
 
-        ProcedureMapping.TryAdd(procA, procB);
+        ProcedureMapping.TryAdd(cmdA.Proc, cmdB.Proc);
         return true;
     }
 
@@ -201,11 +242,15 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
     {
         if (cmdA.Lhss.Count != cmdB.Lhss.Count ||
             cmdA.Rhss.Count != cmdB.Rhss.Count)
+        {
             return false;
-        
+        }
+
         if (cmdA.Lhss.Zip(cmdB.Lhss).Any(p => !EqualsStructuralExpr(p.First.AsExpr, p.Second.AsExpr)) ||
             cmdA.Rhss.Zip(cmdB.Rhss).Any(p => !EqualsStructuralExpr(p.First, p.Second)))
+        {
             return false;
+        }
 
         return true;
     }
@@ -231,19 +276,22 @@ public class ImplementationComparer(ReadOnlyDictionary<string, string> functionM
 /// If a function mapping is not passed, the assumption is that the functions
 /// must have the same name (no mapping is created).
 /// </summary>
-public class ExprComparatorWithRenaming(Dictionary<Variable, Variable> variableMapping,
-                                        ReadOnlyDictionary<string, string> functionMapping)
+public class ExprComparatorWithRenaming(BiDictionary<Variable, Variable> variableMapping,
+                                        BiDictionary<string, string> functionMapping)
 {
-    private readonly Dictionary<Variable, Variable> mapping = new(variableMapping);
-    public Dictionary<Variable, Variable> GetUpdatedVariableMapping => mapping;
+    public BiDictionary<Variable, Variable> GetUpdatedVariableMapping { get; } = new(variableMapping);
 
     public bool Compare(Expr? exprA, Expr? exprB)
     {
         if (exprA == null || exprB == null)
+        {
             return exprA == exprB;
-        
+        }
+
         if (exprA.GetType() != exprB.GetType())
+        {
             return false;
+        }
 
         return (exprA, exprB) switch
         {
@@ -262,23 +310,15 @@ public class ExprComparatorWithRenaming(Dictionary<Variable, Variable> variableM
 
     private bool CompareIdentifierExpr(IdentifierExpr a, IdentifierExpr b)
     {
-        if (mapping.TryGetValue(a.Decl, out var bVar))
-        {
-            return b.Name.Equals(bVar.Name);
-        }
-
-        // Also check for a conflict in the other direction
-        if (mapping.ContainsValue(b.Decl))
-            return false;
-
-        mapping.Add(a.Decl, b.Decl);
-        return true;
+        return GetUpdatedVariableMapping.TryAddIfNoConflict(a.Decl, b.Decl);
     }
 
     private bool CompareNAryExpr(NAryExpr a, NAryExpr b)
     {
         if (a.Args.Count != b.Args.Count)
+        {
             return false;
+        }
 
         switch (a.Fun)
         {
@@ -287,16 +327,17 @@ public class ExprComparatorWithRenaming(Dictionary<Variable, Variable> variableM
                 MapStore or TypeCoercion or UnaryOperator:
             {
                 if (!a.Fun.FunctionName.Equals(b.Fun.FunctionName))
+                {
                     return false;
+                }
                 break;
             }
             case FunctionCall _:
             {
-                if (functionMapping.TryGetValue(a.Fun.FunctionName, out var bFunctionName) &&
-                    !b.Fun.FunctionName.Equals(bFunctionName))
+                if (!functionMapping.TryAddIfNoConflict(a.Fun.FunctionName, b.Fun.FunctionName))
+                {
                     return false;
-                else if (!a.Fun.FunctionName.Equals(b.Fun.FunctionName))
-                    return false;
+                }
                 break;
             }
             default:
@@ -306,7 +347,9 @@ public class ExprComparatorWithRenaming(Dictionary<Variable, Variable> variableM
         for (var i = 0; i < a.Args.Count; i++)
         {
             if (!Compare(a.Args[i], b.Args[i]))
+            {
                 return false;
+            }
         }
         return true;
     }
@@ -316,20 +359,26 @@ public class ExprComparatorWithRenaming(Dictionary<Variable, Variable> variableM
         if (a.Kind != b.Kind
             || !a.TypeParameters.SequenceEqual(b.TypeParameters)
             || a.Dummies.Count != b.Dummies.Count)
+        {
             return false;
+        }
 
         // To handle dummies, we create a new ExprComparator only for this expr,
         // which contains the dummy mapping in the two expressions. After
         // comparison, we eliminate dummies but preserve any non-dummy variables
         // in the new mapping.
-        Dictionary<Variable, Variable> mappingWithDummies = new(mapping);
+        BiDictionary<Variable, Variable> mappingWithDummies = new(GetUpdatedVariableMapping);
         a.Dummies.Zip(b.Dummies).ForEach(p => mappingWithDummies.Add(p.First, p.Second));
         var comp = new ExprComparatorWithRenaming(mappingWithDummies, functionMapping);
         if (!comp.Compare(a.Body, b.Body))
+        {
             return false;
+        }
+
         var newMappingWithDummies = comp.GetUpdatedVariableMapping;
         var newKeysWithoutDummies = newMappingWithDummies.Keys.Except(mappingWithDummies.Keys);
-        newKeysWithoutDummies.ForEach(k => mapping.Add(k, newMappingWithDummies[k]));
+        newKeysWithoutDummies.ForEach(k =>
+            GetUpdatedVariableMapping.Add(k, newMappingWithDummies.GetValueByKey(k)));
         return true;
     }
 }

--- a/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
+++ b/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
@@ -38,7 +38,6 @@ public class ImplementationComparer(BiDictionary<string, string> functionMapping
     public BiDictionary<Block, Block> BlockMapping = new();
     public BiDictionary<Variable, Variable> GlobalVarMapping = new();
     public BiDictionary<Procedure, Procedure> ProcedureMapping = new();
-    private HashSet<Absy> alreadyMappedValues = new();
 
     public bool Compare(Implementation? implA, Implementation? implB)
     {
@@ -273,8 +272,6 @@ public class ImplementationComparer(BiDictionary<string, string> functionMapping
 /// Structurally compares two expressions, ignoring variable renaming.
 /// It will build up a variable mapping in the process. Any pairs in the
 /// input mapping will be used during the comparison, but are not needed.
-/// If a function mapping is not passed, the assumption is that the functions
-/// must have the same name (no mapping is created).
 /// </summary>
 public class ExprComparatorWithRenaming(BiDictionary<Variable, Variable> variableMapping,
                                         BiDictionary<string, string> functionMapping)

--- a/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
+++ b/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
@@ -256,8 +256,11 @@ public class ImplementationComparer(BiDictionary<string, string> functionMapping
 
     private bool EqualsStructuralHavoc(HavocCmd cmdA, HavocCmd cmdB)
     {
+        // TODO: This can be improved, for instance by looking at the
+        //       existing maps to try and align the variables.
         return cmdA.Vars.Count == cmdB.Vars.Count &&
-               cmdA.Vars.Zip(cmdB.Vars).All(p => EqualsStructuralExpr(p.First, p.Second));
+               cmdA.Vars.OrderBy(v => v.Name).Zip(cmdB.Vars.OrderBy(v => v.Name))
+                   .All(p => EqualsStructuralExpr(p.First, p.Second));
     }
 
     private bool IsIrrelevantCommand(Cmd cmd)

--- a/Sources/SymDiff/source/BoogieStructuralDiffManager.cs
+++ b/Sources/SymDiff/source/BoogieStructuralDiffManager.cs
@@ -9,93 +9,101 @@ namespace SymDiff.source;
 
 public static class BoogieStructuralDiffManager
 {
-  // This is currently quite restrictive, but should work for simple changes
-  // that do not change the control flow, and should be insensitive to block
-  // labels.
-  public static bool CanComputeDiff(this Implementation implA, Implementation implB,
-                                    out Dictionary<Block, Block> blockMapping)
-  {
-    blockMapping = new Dictionary<Block, Block>();
-    if (implA.Blocks == null || implB.Blocks == null || implA.Blocks.Count != implB.Blocks.Count) 
-      return false;
-    Graph<Block> graphA = Program.GraphFromImpl(implA);
-    Graph<Block> graphB = Program.GraphFromImpl(implB);
-    if (graphA.Edges.Count() != graphB.Edges.Count())
-      return false;
-    // TODO: use a graph isomorphism below rather than ordering by name!
-    foreach (var ((blkA1, blkA2), (blkB1, blkB2)) in
-             graphA.Edges.OrderBy(p => p.Item1.Label)
-               .Zip(graphB.Edges.OrderBy(p => p.Item1.Label)))
+    // This is currently quite restrictive, but should work for simple changes
+    // that do not change the control flow, and should be insensitive to block
+    // labels.
+    public static bool CanComputeDiff(this Implementation implA, Implementation implB,
+                                      out BiDictionary<Block, Block> blockMapping)
     {
-      var blocksToCompare = new List<(Block, Block)>{ (blkA1, blkB1), (blkA2, blkB2) };
-      foreach (var (blkA, blkB) in blocksToCompare)
-      {
-        if (blockMapping.TryGetValue(blkA, out var blkInMap))
+        blockMapping = new BiDictionary<Block, Block>();
+        if (implA.Blocks == null || implB.Blocks == null || implA.Blocks.Count != implB.Blocks.Count)
         {
-          if (!blkInMap.Label.Equals(blkB.Label))
-          {
-            blockMapping.Clear();
             return false;
-          }
         }
-        else
+
+        Graph<Block> graphA = Program.GraphFromImpl(implA);
+        Graph<Block> graphB = Program.GraphFromImpl(implB);
+        if (graphA.Edges.Count() != graphB.Edges.Count())
         {
-          blockMapping.Add(blkA, blkB);
+            return false;
         }
-      }
+
+        // TODO: use a graph isomorphism below rather than ordering by name!
+        foreach (var ((blkA1, blkA2), (blkB1, blkB2)) in
+                 graphA.Edges.OrderBy(p => p.Item1.Label)
+                     .Zip(graphB.Edges.OrderBy(p => p.Item1.Label)))
+        {
+            var blocksToCompare = new List<(Block, Block)>{ (blkA1, blkB1), (blkA2, blkB2) };
+            foreach (var (blkA, blkB) in blocksToCompare)
+            {
+                if (!blockMapping.TryAddIfNoConflict(blkA, blkB))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
     }
 
-    return true;
-  }
-
-  public static Dictionary<Block, Block> GetBlocksThatDiffer(Dictionary<Block, Block> blockMapping,
-                                                             ReadOnlyDictionary<string, string> functionMapping)
-  {
-    Dictionary<Block, Block> blocksThatDiffer = new();
-    var comparer = new ImplementationComparer(functionMapping);
-    foreach (var (blkA, blkB) in blockMapping)
+    public static Dictionary<Block, Block> GetBlocksThatDiffer(BiDictionary<Block, Block> blockMapping,
+                                                               BiDictionary<string, string> functionMapping)
     {
-      if (!comparer.Compare(blkA, blkB))
-      {
-        blocksThatDiffer.Add(blkA, blkB);
-      }
+        Dictionary<Block, Block> blocksThatDiffer = new();
+        var comparer = new ImplementationComparer(functionMapping);
+        foreach (var (blkA, blkB) in blockMapping)
+        {
+            if (!comparer.Compare(blkA, blkB))
+            {
+                blocksThatDiffer.Add(blkA, blkB);
+            }
+        }
+        foreach (var (blkA, blkB) in comparer.BlockMapping)
+        {
+            if (blockMapping.GetValueByKey(blkA) != blkB)
+            {
+                throw new Exception("Inconsistent block mapping!");
+            }
+        }
+
+        return blocksThatDiffer;
     }
-    foreach (var (blkA, blkB) in comparer.BlockMapping)
-      if (blockMapping[blkA] != blkB)
-        throw new Exception("Inconsistent block mapping!");
 
-    return blocksThatDiffer;
-  }
-
-  /// <summary>
-  /// Given two implementations, groups their blocks by the number of commands they have,
-  /// and structurally compares every pair with the same number of commands. If a pair
-  /// is structurally equivalent, the mappings that made the structural equivalence
-  /// possible will be in the returned ImplementationComparer.
-  /// </summary>
-  public static ImplementationComparer
-    GuessMappings(Implementation implA,
-                  Implementation implB,
-                  ReadOnlyDictionary<string, string> functionMapping)
-  {
-    var comparer = new ImplementationComparer(functionMapping);
+    /// <summary>
+    /// Given two implementations, groups their blocks by the number of commands they have,
+    /// and structurally compares every pair with the same number of commands. If a pair
+    /// is structurally equivalent, the mappings that made the structural equivalence
+    /// possible will be in the returned ImplementationComparer.
+    /// </summary>
+    public static ImplementationComparer
+        GuessMappings(Implementation implA,
+                      Implementation implB,
+                      BiDictionary<string, string> functionMapping)
+    {
+        var comparer = new ImplementationComparer(functionMapping);
       
-    var cmdCountToBlocksA = implA.Blocks.GroupBy(blk => blk.Cmds.Count)
-      .Where(p => p.Key > 0) // we need at least one command
-      .OrderBy(p => -p.Key); // decreasing order
-    var cmdCountToBlocksB = implB.Blocks.GroupBy(blk => blk.Cmds.Count)
-      .ToDictionary(p => p.Key, p => p.ToList());
+        var cmdCountToBlocksA = implA.Blocks.GroupBy(blk => blk.Cmds.Count)
+            .Where(p => p.Key > 0) // we need at least one command
+            .OrderBy(p => -p.Key); // decreasing order
+        var cmdCountToBlocksB = implB.Blocks.GroupBy(blk => blk.Cmds.Count)
+            .ToDictionary(p => p.Key, p => p.ToList());
 
-    foreach (var groupA in cmdCountToBlocksA)
-    {
-      var (cmdCount, blocksA) = (groupA.Key, groupA.ToList());
-      if (!cmdCountToBlocksB.ContainsKey(cmdCount)) continue;
-      var blocksB = cmdCountToBlocksB[cmdCount];
-      foreach (var blkA in blocksA)
-        foreach (var blkB in blocksB)
-          if(comparer.Compare(blkA, blkB)) // the mappings are only updated on equivalence
-            break; // move on to next blkA if there is a match
+        foreach (var groupA in cmdCountToBlocksA)
+        {
+            var (cmdCount, blocksA) = (groupA.Key, groupA.ToList());
+            if (!cmdCountToBlocksB.ContainsKey(cmdCount)) continue;
+            var blocksB = cmdCountToBlocksB[cmdCount];
+            foreach (var blkA in blocksA)
+            {
+                foreach (var blkB in blocksB)
+                {
+                    if (comparer.Compare(blkA, blkB)) // the mappings are only updated on equivalence
+                    {
+                        break; // move on to next blkA if there is a match
+                    }
+                }
+            }
+        }
+        return comparer;
     }
-    return comparer;
-  }
 }

--- a/Sources/SymDiff/source/Config.cs
+++ b/Sources/SymDiff/source/Config.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Boogie;
 using SymDiffUtils;
 
@@ -74,6 +75,18 @@ namespace SDiff
       foreach (var d in this)
         dict.Add(d.fst.fst, d.fst.snd);
       return dict;
+    }
+
+    public Dictionary<string, string> ToProcedureDictionaryWithoutPrefix(string keyPrefix, string valuePrefix)
+    {
+        var dict = new Dictionary<string, string>();
+        foreach (var d in this)
+        {
+            var key = d.fst.fst.StartsWith(keyPrefix) ? d.fst.fst.Substring(keyPrefix.Length) : d.fst.fst;
+            var value = d.fst.snd.StartsWith(valuePrefix) ? d.fst.snd.Substring(valuePrefix.Length) : d.fst.snd;
+            dict.Add(key, value);
+        }
+        return dict;
     }
 
     public ParamMap FindPair(string s1, string s2)

--- a/Sources/SymDiff/source/Config.cs
+++ b/Sources/SymDiff/source/Config.cs
@@ -184,30 +184,18 @@ namespace SDiff
 
   public class Config
   {
-    private ProcedureMap procMap;
-    private ProcedureMap functionMap;
-    public ProcedureMap FunctionMap
-    {
-      get { return functionMap; }
-    }
+    public ProcedureMap ProcedureMap { get; }
+
+    public ProcedureMap FunctionMap { get; }
 
     private ParamMap globalMap;
-    public ParamMap GlobalMap
-    {
-      get { return new ParamMap(globalMap); }
-    }
+    public ParamMap GlobalMap => new(globalMap);
 
     private ParamMap typeMap;
-    public ParamMap TypeMap
-    {
-      get { return new ParamMap(typeMap); }
-    }
+    public ParamMap TypeMap => new(typeMap);
 
     private ParamMap constMap;
-    public ParamMap ConstMap
-    {
-      get { return new ParamMap(constMap); }
-    }
+    public ParamMap ConstMap => new(constMap);
 
     public Config(string filename) : this()
     {
@@ -238,8 +226,8 @@ namespace SDiff
 
     public Config()
     {
-      procMap = new ProcedureMap("procedure");
-      functionMap = new ProcedureMap("function");
+      ProcedureMap = new ProcedureMap("procedure");
+      FunctionMap = new ProcedureMap("function");
       globalMap = new ParamMap();
       typeMap = new ParamMap();
       constMap = new ParamMap();
@@ -247,14 +235,14 @@ namespace SDiff
 
     public void AddProcedure(Duple<HDuple<string>, ParamMap> mapping)
     {
-      if (procMap.Exists(p => p.fst.fst.Equals(mapping.fst.fst)))
+      if (ProcedureMap.Exists(p => p.fst.fst.Equals(mapping.fst.fst)))
         throw new ArgumentException($"{mapping.fst.fst} already exists in config.");
-      procMap.Add(mapping);
+      ProcedureMap.Add(mapping);
     }
 
     public void AddFunction(Duple<HDuple<string>, ParamMap> mapping)
     {
-      functionMap.Add(mapping);
+      FunctionMap.Add(mapping);
     }
 
     public void AddGlobal(HDuple<string> mapping)
@@ -316,39 +304,39 @@ namespace SDiff
 
     private bool ParseProcedure(string l)
     {
-      ParseIntoProcedureMap(l, procMap);
+      ParseIntoProcedureMap(l, ProcedureMap);
       return false;
     }
 
     private bool ParseFunction(string l)
     {
-      ParseIntoProcedureMap(l, functionMap);
+      ParseIntoProcedureMap(l, FunctionMap);
       return false;
     }
 
     public ParamMap FindProcedure(string f1, string f2)
     {
-      return procMap.FindPair(f1, f2);
+      return ProcedureMap.FindPair(f1, f2);
     }
 
     public ParamMap FindFunction(string f1, string f2)
     {
-      return functionMap.FindPair(f1, f2);
+      return FunctionMap.FindPair(f1, f2);
     }
 
     public List<HDuple<string>> GetProcedureAssocList()
     {
-      return procMap.ToProcedureAssocList();
+      return ProcedureMap.ToProcedureAssocList();
     }
 
     public Dictionary<string, string> GetProcedureDictionary()
     {
-      return procMap.ToProcedureDictionary();
+      return ProcedureMap.ToProcedureDictionary();
     }
 
     public string LookupFunction(string f)
     {
-      foreach (var d in procMap)
+      foreach (var d in ProcedureMap)
         if (d.fst.fst == f)
           return d.fst.snd;
       return null;
@@ -363,10 +351,10 @@ namespace SDiff
         s += "#types\ntypes: " + typeMap + "\n";
       if (constMap.Count != 0)
         s += "#constants\nconstants: " + constMap + "\n";
-      if (functionMap.Count != 0)
-        s += "#functions\n" + functionMap + "\n";
-      if (procMap.Count != 0)
-        s += "#procedures\n" + procMap + "\n";
+      if (FunctionMap.Count != 0)
+        s += "#functions\n" + FunctionMap + "\n";
+      if (ProcedureMap.Count != 0)
+        s += "#procedures\n" + ProcedureMap + "\n";
       return s;
     }
   }

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -1536,7 +1536,7 @@ namespace SDiff
                 var p1Impl = p1.Implementations.First(impl => impl.Name.Equals(p1ImplName));
                 var p2ImplName = p2ImplNamePrefixed.Replace(p2Prefix + ".", "");
                 var p2Impl = p2.Implementations.First(impl => impl.Name.Equals(p2ImplName));
-                var functionMapping = new ReadOnlyDictionary<string, string>(
+                var functionMapping = new BiDictionary<string, string>(
                     cfg.FunctionMap.Select(p => (p.fst.fst, p.fst.snd)).ToDictionary());
                 var comparer = BoogieStructuralDiffManager.GuessMappings(p1Impl, p2Impl, functionMapping);
                 var orderedLocalVars1 = new List<Variable>();
@@ -1976,7 +1976,7 @@ namespace SDiff
                 {
                     throw new VerificationException($"Incorrect configuration: could not find {p2Name} in {v2name}");
                 }
-                var functionMapping = new ReadOnlyDictionary<string, string>(
+                var functionMapping = new BiDictionary<string, string>(
                     cfg.FunctionMap.Select(p => (p.fst.fst, p.fst.snd)).ToDictionary());
                 // TODO: pass globalMapping and procedureMapping too.
                 if (p1Impl.EqualsStructural(p2Impl, functionMapping,

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -1537,7 +1537,7 @@ namespace SDiff
                 var p2ImplName = p2ImplNamePrefixed.Replace(p2Prefix + ".", "");
                 var p2Impl = p2.Implementations.First(impl => impl.Name.Equals(p2ImplName));
                 var functionMapping = new BiDictionary<string, string>(
-                    cfg.FunctionMap.Select(p => (p.fst.fst, p.fst.snd)).ToDictionary());
+                    cfg.FunctionMap.ToProcedureDictionaryWithoutPrefix(p1Prefix + ".", p2Prefix + ".")); 
                 var comparer = BoogieStructuralDiffManager.GuessMappings(p1Impl, p2Impl, functionMapping);
                 var orderedLocalVars1 = new List<Variable>();
                 var orderedLocalVars2 = new List<Variable>();
@@ -1977,7 +1977,7 @@ namespace SDiff
                     throw new VerificationException($"Incorrect configuration: could not find {p2Name} in {v2name}");
                 }
                 var functionMapping = new BiDictionary<string, string>(
-                    cfg.FunctionMap.Select(p => (p.fst.fst, p.fst.snd)).ToDictionary());
+                    cfg.FunctionMap.ToProcedureDictionaryWithoutPrefix(p1Prefix + ".", p2Prefix + "."));
                 // TODO: pass globalMapping and procedureMapping too.
                 if (p1Impl.EqualsStructural(p2Impl, functionMapping,
                         out var procMapping, out var globalsMapping, out var localsMapping))


### PR DESCRIPTION
Extracted loop procedure parameters are a subset of the containing implementation’s in/out parameters and local variables. During extraction, the order of parameters are determined by the name of those variables. This is brittle, because local variable names can differ between translations, therefore ordering them on both sides by name might not lead to a correct alignment. It is also possible that one of the parameters does not exist on the other side, which is easier to detect.

This PR adds a heuristic that tries to compute a mapping of variables using structurally equivalent blocks of the implementation.

The blocks are sorted by the number of commands they have and the heuristic attempts to find structurally equivalent blocks starting from the ones with the most commands (which are more likely to be actually equivalent blocks). The mapping is unchanged on conflicts.  It might be that some variables that will become the parameters of the extracted procedure are left unmapped, those variables are ordered by name as before.

### Other changes
- Fixes a bug where the prefixed versions of function names were used instead of the non-prefixed ones during structural equivalence.
- Small refactoring of structural equivalence code and the configuration class.
- Use bijective maps during structural equivalence.
- If the procedure/global names are detected to be different in the compared programs during structural equivalence, a warning is emitted in case the user is using the automatic configuration generation of SymDiff.