### PR TITLE
Use parameter names on both sides when guessing configuration

### DIFF
--- a/Sources/SymDiff/source/Driver.cs
+++ b/Sources/SymDiff/source/Driver.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Boogie;
 using SymDiffUtils;
 
@@ -393,20 +394,20 @@ namespace SDiff
             throw new Exception("Could not initialize Boogie during config generation.");
 
         // First program
-        Program p = BoogieUtils.ParseProgram(first);
-        if (p == null)
+        Program p1 = BoogieUtils.ParseProgram(first);
+        if (p1 == null)
             throw new Exception("Could not parse the first program during config generation.");
 
-        BoogieUtils.ResolveProgram(p, first, BoogieUtils.BoogieOptions);
-        BoogieUtils.TypecheckProgram(p, first, BoogieUtils.BoogieOptions);
+        BoogieUtils.ResolveProgram(p1, first, BoogieUtils.BoogieOptions);
+        BoogieUtils.TypecheckProgram(p1, first, BoogieUtils.BoogieOptions);
 
         // Second program
-        Program q = BoogieUtils.ParseProgram(second);
-        if (q == null)
+        Program p2 = BoogieUtils.ParseProgram(second);
+        if (p2 == null)
             throw new Exception("Could not parse the second program during config generation.");
 
-        BoogieUtils.ResolveProgram(q, second, BoogieUtils.BoogieOptions);
-        BoogieUtils.TypecheckProgram(q, second, BoogieUtils.BoogieOptions);
+        BoogieUtils.ResolveProgram(p2, second, BoogieUtils.BoogieOptions);
+        BoogieUtils.TypecheckProgram(p2, second, BoogieUtils.BoogieOptions);
 
 
         first = Path.GetFileNameWithoutExtension(first) + '.';
@@ -415,61 +416,81 @@ namespace SDiff
         Config config = new Config();
 
         //store the procs of q by name
-        Dictionary<string, Declaration> qProcs = new Dictionary<string, Declaration>();
-        Dictionary<string, HashSet<string>> qLoops = new Dictionary<string, HashSet<string>>();
+        Dictionary<string, Procedure> prog2Procedures = new Dictionary<string, Procedure>();
+        Dictionary<string, HashSet<string>> p2Loops = new Dictionary<string, HashSet<string>>();
 
-        foreach (Declaration d in q.TopLevelDeclarations)
+        foreach (var d in p2.TopLevelDeclarations)
         {
-            var proc = d as Procedure;
-            if (proc != null)
+            if (d is Procedure procedure)
             {
-                qProcs.Add(proc.Name, proc);
-                if (proc.Name.Contains("_loop_"))
+                prog2Procedures.Add(procedure.Name, procedure);
+                if (procedure.Name.Contains("_loop_"))
                 {
-                    int indx = proc.Name.IndexOf("_loop_");
-                    string loopProc = proc.Name.Substring(0, indx);
-                    if (!qLoops.ContainsKey(loopProc))
-                        qLoops.Add(loopProc, new HashSet<string>());
-                    qLoops[loopProc].Add(proc.Name);
+                    int indx = procedure.Name.IndexOf("_loop_");
+                    string loopProcedure = procedure.Name.Substring(0, indx);
+                    if (!p2Loops.ContainsKey(loopProcedure))
+                        p2Loops.Add(loopProcedure, new HashSet<string>());
+                    p2Loops[loopProcedure].Add(procedure.Name);
 
                 }
             }
         }
 
-        foreach (Declaration d in p.TopLevelDeclarations)
+        foreach (Declaration d in p1.TopLevelDeclarations)
         {
-            var proc = d as Procedure;
-            if (proc != null)
+            if (d is Procedure p1Procedure)
             {
-                var pmap = new ParamMap();
-                foreach (Variable v in proc.InParams)
-                    pmap.Add(new HDuple<string>(v.Name, v.Name));
-                foreach (Variable v in proc.OutParams)
-                    pmap.Add(new HDuple<string>(v.Name, v.Name));
-
-                //config.AddProcedure(new Duple<HDuple<string>, ParamMap>(new HDuple<string>(first + proc.Name, second + proc.Name), pmap));
-
-                if (qProcs.ContainsKey(proc.Name))
-                    config.AddProcedure(new Duple<HDuple<string>, ParamMap>(new HDuple<string>(first + proc.Name, second + proc.Name), pmap));
+                if (prog2Procedures.TryGetValue(p1Procedure.Name, out var p2Procedure))
+                {
+                    if (p1Procedure.InParams.Count != p2Procedure.InParams.Count ||
+                        p1Procedure.OutParams.Count != p2Procedure.OutParams.Count)
+                    {
+                        Log.Out(Log.Warning, $"Could not align input arguments for" +
+                                             $" {p1Procedure.EmitSignature()} and {p2Procedure.EmitSignature()}." +
+                                             $" Trying to align existing arguments in order.");
+                    }
+                    var pmap = new ParamMap();
+                    foreach (var (v1, v2) in p1Procedure.InParams.ZipShortest(p2Procedure.InParams))
+                        pmap.Add(new HDuple<string>(v1.Name, v2.Name));
+                    foreach (var (v1, v2) in p1Procedure.OutParams.ZipShortest(p2Procedure.OutParams))
+                        pmap.Add(new HDuple<string>(v1.Name, v2.Name));
+                    config.AddProcedure(new Duple<HDuple<string>, ParamMap>(
+                        new HDuple<string>(first + p1Procedure.Name, second + p1Procedure.Name), pmap));
+                }
                 else //match loops (A BIG HACK that pretends that the enclosing procedure has only one loop and the mappings are same)
                 {
-                    if (proc.Name.Contains("_loop_"))
+                    if (p1Procedure.Name.Contains("_loop_"))
                     {
-                        int indx = proc.Name.IndexOf("_loop_");
-                        string loopProc = proc.Name.Substring(0, indx);
-                        if (qLoops.ContainsKey(loopProc) &&
-                            qLoops[loopProc].Count == 1)
+                        int indx = p1Procedure.Name.IndexOf("_loop_");
+                        string loopProc = p1Procedure.Name.Substring(0, indx);
+                        if (p2Loops.ContainsKey(loopProc) &&
+                            p2Loops[loopProc].Count == 1)
                         {
-                            HashSet<string> matchQProcs = qLoops[loopProc];
-                            string qProcName = "";
+                            HashSet<string> matchQProcs = p2Loops[loopProc];
+                            string p2ProcName = "";
                             foreach (string s in matchQProcs) //ugly way to get the singleton string
-                                qProcName = s;
+                                p2ProcName = s;
 
-                            config.AddProcedure(new Duple<HDuple<string>, ParamMap>(new HDuple<string>(first + proc.Name, second + qProcName), pmap));
+                            // TODO: The logic here can be merged with the first branch. Although it might also make sense
+                            // to simply eliminate this hack now that loop extraction can be done in SymDiff. Keeping
+                            // to preserve old functionality.
+                            p2Procedure = p2.Procedures.First(p => p.Name.Equals(loopProc));
 
+                            if (p1Procedure.InParams.Count != p2Procedure.InParams.Count ||
+                                p1Procedure.OutParams.Count != p2Procedure.OutParams.Count)
+                            {
+                                Log.Out(Log.Warning, $"Could not align input arguments for" +
+                                                     $" {p1Procedure.EmitSignature()} and {p2Procedure.EmitSignature()}." +
+                                                     $" Trying to align existing arguments in order.");
+                            }
+
+                            var pmap = new ParamMap();
+                            foreach (var (v1, v2) in p1Procedure.InParams.ZipShortest(p2Procedure.InParams))
+                                pmap.Add(new HDuple<string>(v1.Name, v2.Name));
+                            foreach (var (v1, v2) in p1Procedure.OutParams.ZipShortest(p2Procedure.OutParams))
+                                pmap.Add(new HDuple<string>(v1.Name, v2.Name));
+                            config.AddProcedure(new Duple<HDuple<string>, ParamMap>(new HDuple<string>(first + p1Procedure.Name, second + p2ProcName), pmap));
                         }
-
-
                     }
                 }
             }

--- a/Sources/SymDiffUtils/Utils.cs
+++ b/Sources/SymDiffUtils/Utils.cs
@@ -195,6 +195,18 @@ namespace SymDiffUtils
                 nl.Add(v);
             return nl;
         }
+        
+        /// <summary>
+        /// Zips the two lists, but the list with the fewer items decides the
+        /// length of the new list (like the `zip` in Python).
+        /// </summary>
+        public static List<(T1, T2)> ZipShortest<T1, T2>(this List<T1> list1, List<T2> list2)
+        {
+            var minLength = Math.Min(list1.Count, list2.Count);
+            return Enumerable.Range(0, minLength)
+                .Select(i => (list1[i], list2[i]))
+                .ToList();
+        }
     }
 
     public class Triple<T1, T2, T3> : Duple<T1, T2>

--- a/Sources/SymDiffUtils/boogieUtils.cs
+++ b/Sources/SymDiffUtils/boogieUtils.cs
@@ -8,7 +8,7 @@ using System.Linq;
 
 namespace SymDiffUtils
 {
-    public class BoogieUtils
+    public static class BoogieUtils
     {
         public static CommandLineOptions BoogieOptions;
         public static bool InitializeBoogie(string clo)
@@ -79,6 +79,10 @@ namespace SymDiffUtils
             return false;
         }
 
+        public static string EmitSignature(this Procedure p)
+        {
+            return p.Name + "(" + string.Join(",", p.InParams) + "):(" + string.Join(",", p.OutParams) + ")";
+        }
 
         /// <summary>
         /// TODO: Copied from Rootcause, refactor 


### PR DESCRIPTION
`GuessConfig` was assuming that procedure parameters always have the same names in the compared programs. This PR removes that assumption and uses actual parameter names when generating the configuration.