### PR TITLE
Custom heap comparison

### DIFF
--- a/Sources/SymDiff/source/BoogieVerify.cs
+++ b/Sources/SymDiff/source/BoogieVerify.cs
@@ -992,12 +992,20 @@ namespace SDiff
                         if (Options.PreciseDifferentialInline)
                         {
                             List<Declaration> consts = prog.TopLevelDeclarations.Where(x => x is Constant).ToList();
-                            ProcessCounterexamplesWOSymbolicOut(
-                                SErrors, globals, vt.Eq.LocVars, vtLeftProcImpl, vtRightProcImpl, consts, [SErrors[0].Cex.Model]);
+                            try {
+                                ProcessCounterexamplesWOSymbolicOut(
+                                    SErrors, globals, vt.Eq.LocVars, vtLeftProcImpl, vtRightProcImpl, consts, [SErrors[0].Cex.Model]);
+                            } catch (Exception e) {
+                                Log.Out(Log.Normal, "Error producing a counterexample.");
+                            }
                         }
                         else
                         {
-                            ProcessCounterexamples(SErrors, globals, outputVars, newProg, vtLeftProcImpl, vtRightProcImpl);
+                            try {
+                                ProcessCounterexamples(SErrors, globals, outputVars, newProg, vtLeftProcImpl, vtRightProcImpl);
+                            } catch (Exception e) {
+                                Log.Out(Log.Normal, "Error producing a counterexample.");
+                            }
                         }
                     }
                 }

--- a/Sources/SymDiff/source/BoogieVerify.cs
+++ b/Sources/SymDiff/source/BoogieVerify.cs
@@ -996,7 +996,7 @@ namespace SDiff
                                 ProcessCounterexamplesWOSymbolicOut(
                                     SErrors, globals, vt.Eq.LocVars, vtLeftProcImpl, vtRightProcImpl, consts, [SErrors[0].Cex.Model]);
                             } catch (Exception e) {
-                                Log.Out(Log.Normal, "Error producing a counterexample.");
+                                Log.Out(Log.Error, "Error producing a counterexample.");
                             }
                         }
                         else
@@ -1004,7 +1004,7 @@ namespace SDiff
                             try {
                                 ProcessCounterexamples(SErrors, globals, outputVars, newProg, vtLeftProcImpl, vtRightProcImpl);
                             } catch (Exception e) {
-                                Log.Out(Log.Normal, "Error producing a counterexample.");
+                                Log.Out(Log.Error, "Error producing a counterexample.");
                             }
                         }
                     }

--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -105,10 +105,10 @@ namespace SDiff
 
         // Is a custom heap comparison method specified?
         public static bool CustomHeapComparison = false;
-        public static Object CustomConfig;
+        public static List<string> ProceduresToCustomCompare;
 
         // Custom comparison delegate
-        public static Func<List<Formal>, List<IdentifierExpr>, List<IdentifierExpr>, Program, Program, BigBlock, List<Variable>, bool> GenerateComparisons;
+        public static Func<List<Formal>, List<IdentifierExpr>, List<IdentifierExpr>, Program, Program, BigBlock, List<Variable>, bool, bool> GenerateComparisons;
 
         #endregion
 

--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -99,6 +99,17 @@ namespace SDiff
 
         #endregion 
 
+        #region Supporting custom heap comparison predicates
+
+        // Is a custom heap comparison method specified?
+        public static bool CustomHeapComparison = false;
+        public static Object CustomConfig;
+
+        // Custom comparison delegate
+        public static Func<List<Formal>, List<IdentifierExpr>, List<IdentifierExpr>, Program, Program, BigBlock, List<Variable>, bool> GenerateComparisons;
+
+        #endregion
+
         //flag and settings for generating C traces
         public const bool GenerateCTrace = true;
 

--- a/Sources/SymDiff/source/RVTCheck.cs
+++ b/Sources/SymDiff/source/RVTCheck.cs
@@ -265,7 +265,7 @@ namespace RVT
             string eqpName = Transform.mkEqProcName(n1.Name, n2.Name);
 
             Duple<Procedure, Implementation> eqp;
-            eqp = Transform.EqualityReduction(n1.Impl, n2.Impl, cfg.FindProcedure(n1.Name, n2.Name), ignores, out outputVars, out _);
+            eqp = Transform.EqualityReduction(n1.Impl, n2.Impl, cfg.FindProcedure(n1.Name, n2.Name), ignores, null, out outputVars, out _);
 
             // if any visible output
             //VerificationTask vt;

--- a/Sources/SymDiff/source/Visitor.cs
+++ b/Sources/SymDiff/source/Visitor.cs
@@ -46,9 +46,15 @@ namespace SDiff
     {
         public bool asserts = false;
         bool makeContractsFree = false; 
+        public bool stripAttributes = true;
         public StripContractsAndAttributes(bool freeContractsFlag)
         {
             makeContractsFree =  freeContractsFlag;
+        }
+        public StripContractsAndAttributes(bool freeContractsFlag, bool attributes)
+        {
+            makeContractsFree =  freeContractsFlag;
+            stripAttributes = attributes;
         }
         public override Procedure VisitProcedure(Procedure node)
         {
@@ -69,7 +75,9 @@ namespace SDiff
                     TempRequireSeq.Add(new Requires(true, e.Condition));
                 }
                 node.Requires = TempRequireSeq;
-                node.Attributes = null;
+                if (stripAttributes) {
+                    node.Attributes = null;
+                }
                 return base.VisitProcedure(node);
             }
                 //changing this //shuvendu
@@ -104,7 +112,9 @@ namespace SDiff
                 {
                     node.Requires = new List<Requires>();
                     node.Ensures = new List<Ensures>();
-                    node.Attributes = null;
+                    if (stripAttributes) {
+                        node.Attributes = null;
+                    }
                 }
                 return base.VisitProcedure(node);
             

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -1048,8 +1048,8 @@ namespace SDiff
                 if (Options.CustomHeapComparison) {
                     bool marked = false;
                     foreach (var x in Options.ProceduresToCustomCompare) {
-                        // Currently, loop_blocks are not compared during custom heap comparison
-                        if (n1.Name.Contains(x.Replace('.', '$')) && !n1.Name.Contains("loop_block")) {
+                        // Currently, blocks are not compared during custom heap comparison
+                        if (n1.Name.Contains(x.Replace('.', '$')) && !n1.Name.Contains("loop_block") && !n1.Name.Contains("outlined_block")) {
                             marked = true;
                         }
                     }
@@ -1826,7 +1826,9 @@ namespace SDiff
             // only "assume" are left, assert p --> assert true, others are removed
             // Inlining attributes should be left in for custom heap comparison predicates 
             if (!Options.CustomHeapComparison) {
-                StripContracts(p1, p2); 
+                StripContracts(p1, p2, false); 
+            } else {
+                StripContracts(p1, p2, true); 
             }
             //RS: Make sure that every requires and ensures is free (does not touch assert)
             Util.MakeContractsFree(p1);
@@ -2066,12 +2068,12 @@ namespace SDiff
             return (outlinedBlockImplPairs, structurallyEquivalentImpls);
         }
 
-        private static void StripContracts(Program p1, Program p2)
+        private static void StripContracts(Program p1, Program p2, bool stripAttributes = true)
         {
             if (Options.StripContracts)
             {
                 //TODO: asserts from inlined body are not visited in the Visitor (so they still stay in /nonmodular)
-                var contractStripper = new StripContractsAndAttributes(Options.freeContracts);
+                var contractStripper = new StripContractsAndAttributes(Options.freeContracts, stripAttributes);
                 contractStripper.asserts = Options.checkAssertsOnly;
                 contractStripper.VisitProgram(p1);
                 contractStripper.VisitProgram(p2);

--- a/Sources/nuget.config
+++ b/Sources/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Sources/nuget.config
+++ b/Sources/nuget.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
-    <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
Adds an option to use a custom EqualityReduction method.
This allows the use of custom heap comparison predicates inside the comparison procedures.
If the custom option is marked, top level declarations such as globals and constants in the merged file are kept separate for both the reference procedure and the other procedure.