### PR TITLE
Minor tweaks to handling of mutual summaries

### DIFF
--- a/Sources/SymDiff/source/MutualSummary.cs
+++ b/Sources/SymDiff/source/MutualSummary.cs
@@ -172,7 +172,7 @@ namespace SDiff
 
         private static void ParseAddtionalMSFile(Program mergedProgram)
         {
-            var ms_file = @".\ms_symdiff_file.bpl";
+            var ms_file = "ms_symdiff_file.bpl";
             if (!System.IO.File.Exists(ms_file)) return;
             Program ms = BoogieUtils.ParseProgram(ms_file);
             //TODO: Have to merge the new types (including datatypes)

--- a/Sources/SymDiff/source/MutualSummary.cs
+++ b/Sources/SymDiff/source/MutualSummary.cs
@@ -737,6 +737,9 @@ namespace SDiff
             exprListR.AddRange(Util.VarSeqToExprSeq(a2));
             exprListR.AddRange(gSeq_p2.Select(x => IdentifierExpr.Ident(x)));
             requiresSeq.Add(new Requires(false, new NAryExpr(new Token(), callMSPre, exprListR)));
+            var modifiesSeq = new List<IdentifierExpr>();
+            modifiesSeq.AddRange(f1.Modifies);
+            modifiesSeq.AddRange(f2.Modifies);
 
             if (Options.checkEquivWithDependencies)
             {
@@ -763,7 +766,7 @@ namespace SDiff
                     ovarSeq,
                     isPure:false,
                     requiresSeq,
-                    new List<IdentifierExpr>(),
+                    modifiesSeq,
                     ensuresSeq);
             mschkProc.AddAttribute("MS_procs", f1.Name, f2.Name);
             mergedProgram.AddTopLevelDeclaration(mschkProc);


### PR DESCRIPTION
- Change path to file with mutual summaries. The path is Windows specific and causes SymDiff to not use user-provided summaries on Unix-like systems.
- Add a modifies clause to `MS_Check` procedures. This fixes an issue where the generated Boogie file `mergedProgSingle.bpl` would not typecheck. Since the mutual summary for `MS(f1,f2)` inlines `f1` and `f2` its modifies clause should include modifies from both `f1` and `f2`.