### PR TITLE
Add flag to emit default mutual summaries

### DIFF
--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -69,6 +69,7 @@ namespace SDiff
         public static bool useMutualSummariesAsAxioms;
         public static bool dontUseHoudiniForMS;
         public static bool useAbstractHoudiniInference;
+        public static bool dumpDefaultMutualSummaries = false; //dump default mutual summaries to aux Boogie file
         public static bool checkMutualPrecondNonTerminating; //use dependencies and Houdini to check for equivalence
         public static bool dontTypeCheckMergedProg;
         public static bool callCorralOnMergedProgram; //invoke corral to check the candidates in mutual summary procedures (for equivalence checking)

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -88,6 +88,7 @@ namespace SDiff
 
           Console.WriteLine("\n[Options for mutual summaryies and DAC]");
           Console.WriteLine("\t -usemutual      \n\t\tuse the CADE'13/FSE'13 mutual summaries (paired with -useMutualSummmariesAsAxioms) with an additional file \"ms_symdiff_file.bpl\"");
+          Console.WriteLine("\t -dumpMS         \n\t\tdump default mutual summaries for matched procedures to ms_symdiff_file.bpl");
           Console.WriteLine("\t -asserts        \n\t\tperforms differential assertion checking (wrt assertions present)");
           Console.WriteLine("\t -useMutualSummmariesAsAxioms \n\t\tuse the mutual summaries (CADE'13) when -usemutual is specified (default FSE'13 encoding even without -asserts)");
           Console.WriteLine("\t -checkEquivWithDependencies \n\t\tuse the FSE'13 encoding for checking equivalence with candidates given by dependency analysis");
@@ -126,6 +127,7 @@ namespace SDiff
 
             //mutual summary related
             Options.mutualSummaryMode = argsList.Remove("-usemutual");
+            Options.dumpDefaultMutualSummaries = argsList.Remove("-dumpMS");
             Options.useMutualSummariesAsAxioms = argsList.Remove("-useMutualSummariesAsAxioms");
             Options.dontUseHoudiniForMS = argsList.Remove("-dontUseHoudiniForMS");
             Options.useAbstractHoudiniInference = argsList.Remove("-useAbstractHoudiniInference");
@@ -1765,7 +1767,7 @@ namespace SDiff
             //just present to test invoking Houdini directly
             if (Options.invokeHoudiniDirectlyOnMergedBpl)
             {
-                MutualSummary.PerformHoudiniInferece(); //invokes houdini in previously generated mergedProgSingle.bpl
+                MutualSummary.PerformHoudiniInference(); //invokes houdini in previously generated mergedProgSingle.bpl
                 return [];
             }
 
@@ -1934,6 +1936,7 @@ namespace SDiff
                     Options.checkMutualPrecondNonTerminating,
                     Options.freeContracts, Options.dontTypeCheckMergedProg,
                     Options.dacEncoding,
+                    Options.dumpDefaultMutualSummaries,
                     Options.callCorralOnMergedProgram);
                 return [];
             }

--- a/Sources/SymDiffUtils/Utils.cs
+++ b/Sources/SymDiffUtils/Utils.cs
@@ -458,6 +458,12 @@ namespace SymDiffUtils
                     return d;
             return null;
         }
+
+        public static Function getFunctionByName(Program p, string name)
+        {
+            return (Function)p.TopLevelDeclarations.FirstOrDefault(x => x is Function && ((Function)x).Name == name);
+        }
+
         public static Declaration getDeclarationByName(string declarationName, IEnumerable<Declaration> prodDeclOrImplList)
         {
             Declaration decl = null;


### PR DESCRIPTION
With -dumpMS, SymDiff will output all mutual summaries it constructs to ms_symdiff_file.bpl.  SymDiff will also consult this file for user defined mutual summaries.  Intended workflow: run SymDiff once, look at mutual summaries it generates, tweak as needed, run SymDiff again.

Note that symdiff -usemutual does *not* run Boogie.  It generates a file called mergedProgSingle.bpl.  Boogie needs to be invoked on this file separately.

This PR also fixes a typo: `PerformHoudiniInferece` to `PerformHoudiniInference`.