### PR TITLE
Add option to specify where to look for mutual summaries and tweak defaults

### DIFF
--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -70,6 +70,7 @@ namespace SDiff
         public static bool dontUseHoudiniForMS;
         public static bool useAbstractHoudiniInference;
         public static bool dumpDefaultMutualSummaries = false; //dump default mutual summaries to aux Boogie file
+        public static string mutualSummariesFile = "ms_symdiff_file.bpl";
         public static bool checkMutualPrecondNonTerminating; //use dependencies and Houdini to check for equivalence
         public static bool dontTypeCheckMergedProg;
         public static bool callCorralOnMergedProgram; //invoke corral to check the candidates in mutual summary procedures (for equivalence checking)

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -89,6 +89,7 @@ namespace SDiff
           Console.WriteLine("\n[Options for mutual summaryies and DAC]");
           Console.WriteLine("\t -usemutual      \n\t\tuse the CADE'13/FSE'13 mutual summaries (paired with -useMutualSummmariesAsAxioms) with an additional file \"ms_symdiff_file.bpl\"");
           Console.WriteLine("\t -dumpMS         \n\t\tdump default mutual summaries for matched procedures to ms_symdiff_file.bpl");
+          Console.WriteLine("\t -msFile:file    \n\t\tfile to search for mutual summaries (default: ms_symdiff_file.bpl)");
           Console.WriteLine("\t -asserts        \n\t\tperforms differential assertion checking (wrt assertions present)");
           Console.WriteLine("\t -useMutualSummmariesAsAxioms \n\t\tuse the mutual summaries (CADE'13) when -usemutual is specified (default FSE'13 encoding even without -asserts)");
           Console.WriteLine("\t -checkEquivWithDependencies \n\t\tuse the FSE'13 encoding for checking equivalence with candidates given by dependency analysis");
@@ -130,6 +131,11 @@ namespace SDiff
             Options.dumpDefaultMutualSummaries = argsList.Remove("-dumpMS");
             Options.useMutualSummariesAsAxioms = argsList.Remove("-useMutualSummariesAsAxioms");
             Options.dontUseHoudiniForMS = argsList.Remove("-dontUseHoudiniForMS");
+            if (argsList.Exists(x => x.StartsWith("-msFile:") || x.StartsWith("/msFile:")))
+            {
+                var msFileOpt = argsList.FirstOrDefault(x => x.StartsWith("-msFile:") || x.StartsWith("/msFile:"));
+                Options.mutualSummariesFile = msFileOpt.Substring("-msFile:".Length);
+            }
             Options.useAbstractHoudiniInference = argsList.Remove("-useAbstractHoudiniInference");
             Options.checkMutualPrecondNonTerminating = argsList.Remove("-checkMutualPrecondNonTerminating");
             Options.freeContracts = argsList.Remove("-freeContracts");
@@ -253,10 +259,6 @@ namespace SDiff
                 else if (args[i].Equals("-checkEquivForRoots") || args[i].Equals("/checkEquivForRoots"))
                 {
                     Options.checkEquivForRoots = true;
-                }
-                else if (args[i].StartsWith("-msFile:") || args[i].StartsWith("/msFile:"))
-                {
-                    Options.mutualSummariesFile = args[i].Substring("-msFile:".Length);
                 }
                 else if (args[i].StartsWith("-main:") || args[i].StartsWith("/main:"))
                 {

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -254,6 +254,10 @@ namespace SDiff
                 {
                     Options.checkEquivForRoots = true;
                 }
+                else if (args[i].StartsWith("-msFile:") || args[i].StartsWith("/msFile:"))
+                {
+                    Options.mutualSummariesFile = args[i].Substring("-msFile:".Length);
+                }
                 else if (args[i].StartsWith("-main:") || args[i].StartsWith("/main:"))
                 {
                     Options.mainProcedure = args[i].Substring("-main:".Length);
@@ -326,9 +330,9 @@ namespace SDiff
                 {
                     cfg = new Config(args[2]);
                 }
-                catch
+                catch (Exception e)
                 {
-                    Console.WriteLine("Failed to parse config file");
+                    Console.WriteLine("Failed to parse config file: " + e.Message);
                     return 1;
                 }
             }


### PR DESCRIPTION
This PR adds the flag `-msFile:<file>`. SymDiff will search `<file>` for mutual summaries. By default `<file>` is set to `ms_symdiff_file.bpl`. Additionally, this PR slightly modifies the default mutual summary generated: parameter alignment information is used when constructing equalities.