### PR TITLE
fix soundness bug

### DIFF
--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -1799,6 +1799,7 @@ namespace SDiff
             }
             else
             {
+                BoogieUtils.BoogieOptions.ProcedureInlining = CoreOptions.Inlining.Spec;
                 Util.InlineProg(p1);
                 Util.InlineProg(p2);
             }


### PR DESCRIPTION
This PR fixes a soundness bug for the following program because the inlining that is happening in SymDiff is somehow still of type inline:assume, instead of inline:spec.
```
public class Test {
    private int g(int n) {
        if (n <= 0) return n;
        return g(n-1);
    }
    public int f(int n) {
        return g(n); // returns min(0,n)
    }
}


public class Test {
    public int f(int n) {
        return n;
    }
}

```