### PR TITLE
Fix issues: call graph roots + mod set computation

### DIFF
--- a/Sources/SymDiff/source/CallGraph.cs
+++ b/Sources/SymDiff/source/CallGraph.cs
@@ -55,7 +55,10 @@ namespace SDiff
 
     public List<List<CallGraphNode>> SCCs;
 
-    public IEnumerable<ISimpleGraphNode> GetChildren() { return Callees.Cast<ISimpleGraphNode>(); }
+    public IEnumerable<ISimpleGraphNode> GetChildren()
+    {
+      return Callees.Filter(p => p != this);
+    }
 
     public HashSet<Variable> ReadSet;
     public List<Variable> ReadSetGlobals

--- a/Sources/SymDiff/source/CallGraphVisitor.cs
+++ b/Sources/SymDiff/source/CallGraphVisitor.cs
@@ -144,7 +144,12 @@ namespace SDiff
           if (assme != null)
             reads.Visit(assme.Expr);
 
-
+          var havc = c as HavocCmd;
+          if (havc != null)
+          {
+            reads.VisitIdentifierExprSeq(havc.Vars);
+            writes.Vars.AddRange(reads.Vars);
+          }
 
         }
       }

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -1030,6 +1030,8 @@ namespace SDiff
 
             var equivalenceResults = new List<EquivalenceResult>();
 
+            Debug.Assert(cg1.GetPostOrder().Count == cg1.GetNodes().Count, "Malformed call graph");
+
             foreach (var n in cg1.GetPostOrder())
             { //the order is topological for non-recursive programs
                 //we're iterating over a topo sort of the first program, but we actually want to


### PR DESCRIPTION
This PR addresses two issues: 1/ SymDiff skips checking equivalence between certain procedure pairs even if they are present in the alignment, and 2/ SymDiff generates Boogie products with incorrect `modifies` clauses. The first issue is cause by recursive procedures not being processed under certain conditions. The second is caused by SymDiff ignoring `havoc`s in merged programs.

If we face issue 2 again, we should add missing cases to `ReadWriteSetDecorator.Visit`. A better approach, however, would be to redo how SymDiff constructs the `modifies` clause for a product procedure: SymDiff should simply combine the `modifies` clauses for the underlying procedures.

@atomb @typerSniper