### PR TITLE
Upgrade to Boogie 3.5.2

### DIFF
--- a/Sources/BoogieWrapper/BoogieWrapper.csproj
+++ b/Sources/BoogieWrapper/BoogieWrapper.csproj
@@ -36,13 +36,13 @@
     <OutputPath>../bin/</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Boogie.BaseTypes" Version="3.1.3" />
-    <PackageReference Include="Boogie.CodeContractsExtender" Version="3.1.3" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
-    <PackageReference Include="Boogie.Model" Version="3.1.3" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.1.3" />
+    <PackageReference Include="Boogie.BaseTypes" Version="3.5.1" />
+    <PackageReference Include="Boogie.CodeContractsExtender" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Model" Version="3.5.1" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/Sources/BoogieWrapper/BoogieWrapper.csproj
+++ b/Sources/BoogieWrapper/BoogieWrapper.csproj
@@ -36,13 +36,13 @@
     <OutputPath>../bin/</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Boogie.BaseTypes" Version="3.5.1" />
-    <PackageReference Include="Boogie.CodeContractsExtender" Version="3.5.1" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
-    <PackageReference Include="Boogie.Model" Version="3.5.1" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
+    <PackageReference Include="Boogie.BaseTypes" Version="3.5.2" />
+    <PackageReference Include="Boogie.CodeContractsExtender" Version="3.5.2" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
+    <PackageReference Include="Boogie.Model" Version="3.5.2" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">

--- a/Sources/BoogieWrapper/source/Wrapper.cs
+++ b/Sources/BoogieWrapper/source/Wrapper.cs
@@ -67,10 +67,10 @@ namespace BoogieWrapper
 
             //RS: Uncomment this
             var newEq = (Implementation)newDict.Get(funcName + "$IMPL");
-            SDiffCounterexamples SErrors;
-            List<Model> errModelList;
+            //SDiffCounterexamples SErrors;
+            //List<Model> errModelList;
 
-            var Result = BoogieVerify.VerifyImplementation(vcgen, newEq, newProg, out SErrors);
+            var Result = BoogieVerify.VerifyImplementation(newProg, fileName, funcName, out var SErrors);
 
             switch (Result)
             {

--- a/Sources/BoogieWrapper/source/Wrapper.cs
+++ b/Sources/BoogieWrapper/source/Wrapper.cs
@@ -35,7 +35,7 @@ namespace BoogieWrapper
             string funcName = args[1];
 
             //TODO: Make it aware of the other Boogie options
-            var boogieOptions = " -doModSetAnalysis -printInstrumented -typeEncoding:m -timeLimit:" + Options.Timeout + " -removeEmptyBlocks:0 -printModel:1 -printModelToFile:model.dmp " + Options.BoogieUserOpts;
+            var boogieOptions = " -inferModifies -printInstrumented -typeEncoding:m -timeLimit:" + Options.Timeout + " -removeEmptyBlocks:0 -printModel:1 -printModelToFile:model.dmp " + Options.BoogieUserOpts;
             SDiff.Boogie.Process.InitializeBoogie(boogieOptions);
 
             Program prog = BoogieUtils.ParseProgram(args[0]);

--- a/Sources/Dependency/Dependency.csproj
+++ b/Sources/Dependency/Dependency.csproj
@@ -49,13 +49,13 @@
   </ItemGroup>
   <ItemGroup>
 <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
-    <PackageReference Include="Boogie.Houdini" Version="3.1.3" />
-    <PackageReference Include="Boogie.Graph" Version="3.1.3" />
-    <PackageReference Include="Boogie.Model" Version="3.1.3" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.1.3" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Houdini" Version="3.5.1" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
+    <PackageReference Include="Boogie.Model" Version="3.5.1" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="source\TaintVisitor.cs" />

--- a/Sources/Dependency/Dependency.csproj
+++ b/Sources/Dependency/Dependency.csproj
@@ -49,13 +49,13 @@
   </ItemGroup>
   <ItemGroup>
 <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
-    <PackageReference Include="Boogie.Houdini" Version="3.5.1" />
-    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
-    <PackageReference Include="Boogie.Model" Version="3.5.1" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
+    <PackageReference Include="Boogie.Houdini" Version="3.5.2" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.2" />
+    <PackageReference Include="Boogie.Model" Version="3.5.2" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="source\TaintVisitor.cs" />

--- a/Sources/Dependency/source/Analysis.cs
+++ b/Sources/Dependency/source/Analysis.cs
@@ -351,7 +351,8 @@ namespace Dependency
                     string procName = items[0].Trim(), procFile = null;
                     // locate the source file for the procedure
                     var impl = program.Implementations.Single(i => i.Name == procName);
-                    impl.Blocks.Find(b => b.Cmds.Count > 0 && b.Cmds[0] is AssertCmd && (procFile = Utils.AttributeUtils.GetSourceFile(b)) != null);
+                    // TODO: the following doesn't do anything?
+                    //impl.Blocks.Find(b => b.Cmds.Count > 0 && b.Cmds[0] is AssertCmd && (procFile = Utils.AttributeUtils.GetSourceFile(b)) != null);
                     myChangeLog.Add(Tuple.Create(procFile, procName, int.Parse(items[1])));
                 }
                 catch (Exception)

--- a/Sources/Dependency/source/Analysis.cs
+++ b/Sources/Dependency/source/Analysis.cs
@@ -351,8 +351,12 @@ namespace Dependency
                     string procName = items[0].Trim(), procFile = null;
                     // locate the source file for the procedure
                     var impl = program.Implementations.Single(i => i.Name == procName);
-                    // TODO: the following doesn't do anything?
-                    //impl.Blocks.Find(b => b.Cmds.Count > 0 && b.Cmds[0] is AssertCmd && (procFile = Utils.AttributeUtils.GetSourceFile(b)) != null);
+                    foreach (var b in impl.Blocks.Where(b => b.Cmds.Count > 0 && b.Cmds[0] is AssertCmd)) {
+                        procFile = Utils.AttributeUtils.GetSourceFile(b);
+                        if (procFile != null) {
+                            break;
+                        }
+                    }
                     myChangeLog.Add(Tuple.Create(procFile, procName, int.Parse(items[1])));
                 }
                 catch (Exception)

--- a/Sources/Dependency/source/DependencyVisitor.cs
+++ b/Sources/Dependency/source/DependencyVisitor.cs
@@ -355,7 +355,7 @@ namespace Dependency
             Block currBlock = worklist.cmdBlocks[node];
             Dependencies dependencies = worklist.GatherPredecessorsState(node, currBlock);
 
-            var succs = node.labelTargets;
+            var succs = node.LabelTargets;
             if (succs.Count > 1)
             { // here we create branchCondVars
                 if (!branchCondVars.ContainsKey(currBlock))

--- a/Sources/Dependency/source/RefineDependency.cs
+++ b/Sources/Dependency/source/RefineDependency.cs
@@ -199,9 +199,8 @@ namespace Dependency
 
             // create body
             List<Block> body = new List<Block>();
-            Block bodyBlock = new Block();
-            body.Add(bodyBlock);
-            bodyBlock.Label = RefineConsts.refinedProcBodyName;
+            List<Cmd> bodyBlockCmds = new List<Cmd>();
+            Block bodyBlock = new Block(Token.NoToken, RefineConsts.refinedProcBodyName, bodyBlockCmds, new ReturnCmd(Token.NoToken));
 
             // first side
             CreateSide(proc, readSet, modSet, actualInputs, recordedReadSet1, actualOutputs, recordedModSet1, bodyBlock);
@@ -210,13 +209,12 @@ namespace Dependency
 
             // create assumptions
             for (int i = 0; i < readSet.Count; i++)
-                bodyBlock.Cmds.Add(new AssumeCmd(new Token(), Expr.Imp(Expr.Ident(inputGuards[i]), Expr.Eq(Expr.Ident(recordedReadSet1[i]), Expr.Ident(recordedReadSet2[i]))))); // ensures bi_k => i_k_1 == i_k_2
+                bodyBlockCmds.Add(new AssumeCmd(new Token(), Expr.Imp(Expr.Ident(inputGuards[i]), Expr.Eq(Expr.Ident(recordedReadSet1[i]), Expr.Ident(recordedReadSet2[i]))))); // ensures bi_k => i_k_1 == i_k_2
 
             // create checks     
             CreateChecks(modSet, equivOutParams, recordedModSet1, recordedModSet2, bodyBlock);
 
-            // create return
-            bodyBlock.TransferCmd = new ReturnCmd(new Token());
+            body.Add(bodyBlock);
 
             // create implementation
             var refineImpl = new Implementation(new Token(), RefineConsts.refinedProcNamePrefix + procName, new List<TypeVariable>(),
@@ -606,7 +604,7 @@ namespace Dependency
 
             var refineImpl = RefineDependencyProgramCreator.CreateCheckDependencyImpl(upperBoundDependencies, lowerBoundDependencies, impl, prog);
             ModSetCollector c = new ModSetCollector(BoogieUtils.BoogieOptions);
-            c.DoModSetAnalysis(prog);
+            c.CollectModifies(prog);
 
             //add callee ensures to procedure
             Declaration[] decls = new Declaration[prog.TopLevelDeclarations.Count()];

--- a/Sources/Dependency/source/Worklist.cs
+++ b/Sources/Dependency/source/Worklist.cs
@@ -93,7 +93,7 @@ namespace Dependency
             }
             else if (node is GotoCmd)
             {
-                foreach (var succ in (node as GotoCmd).labelTargets)
+                foreach (var succ in (node as GotoCmd).LabelTargets)
                 {
                     Absy cmd;
                     if (succ.Cmds.Count > 0)

--- a/Sources/Rootcause/rootcause.csproj
+++ b/Sources/Rootcause/rootcause.csproj
@@ -56,12 +56,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.BaseTypes" Version="3.5.1" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
-    <PackageReference Include="Boogie.Model" Version="3.5.1" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
+    <PackageReference Include="Boogie.BaseTypes" Version="3.5.2" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
+    <PackageReference Include="Boogie.Model" Version="3.5.2" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="source\options_old.cs" />

--- a/Sources/Rootcause/rootcause.csproj
+++ b/Sources/Rootcause/rootcause.csproj
@@ -56,12 +56,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.BaseTypes" Version="3.1.3" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
-    <PackageReference Include="Boogie.Model" Version="3.1.3" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.1.3" />
+    <PackageReference Include="Boogie.BaseTypes" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Model" Version="3.5.1" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="source\options_old.cs" />

--- a/Sources/Rootcause/source/equalityFixes.cs
+++ b/Sources/Rootcause/source/equalityFixes.cs
@@ -3478,7 +3478,7 @@ namespace Rootcause
             {
 
                 GotoCmd gotoCmd = (current.TransferCmd as GotoCmd); if (gotoCmd == null) continue;
-                List<Block> successors = gotoCmd.labelTargets;
+                List<Block> successors = gotoCmd.LabelTargets;
                 foreach (Block successor in successors)
                 {
                     CDFG[current].Item2.Add(successor);
@@ -3553,7 +3553,7 @@ namespace Rootcause
                 AssignCmd lastNode = lastAssign[b];
 
                 GotoCmd gotoCmd = (b.TransferCmd as GotoCmd); if (gotoCmd == null) continue;
-                List<Block> successorBlocks = gotoCmd.labelTargets;
+                List<Block> successorBlocks = gotoCmd.LabelTargets;
                 foreach (Block successorBlock in successorBlocks)
                 {
                     //find firstNode of successorBlock

--- a/Sources/Rootcause/source/main.cs
+++ b/Sources/Rootcause/source/main.cs
@@ -562,7 +562,7 @@ namespace Rootcause
                 new List<BType>(new BType[] { Datatypes.dtType }), BType.Bool);
             foreach (Function f in prog.TopLevelDeclarations.OfType<Function>().ToList())
             {
-                if (QKeyValue.FindBoolAttribute(f.Attributes, "uninterpreted"))
+                if (f.Attributes.FindBoolAttribute("uninterpreted"))
                 {
                     var vars = f.InParams.Cast<Variable>();
                     // BOOGIE WORKAROUND: original: var tVars = vars.Select(x => Tuple.Create(x.Name, x.TypedIdent.Type));

--- a/Sources/Rootcause/source/unsatCoreFromFailure.cs
+++ b/Sources/Rootcause/source/unsatCoreFromFailure.cs
@@ -282,7 +282,7 @@ namespace Rootcause
             public int partition = -1;
             public override GotoCmd VisitGotoCmd(GotoCmd node)
             {
-                var label = node.labelNames;
+                var label = node.LabelNames;
                 if (label != null && label.Count == 1 && label[0].Contains("AA_INSTR_EQ_BODY$1"))
                     partition = node.Line;
                 return base.VisitGotoCmd(node);

--- a/Sources/Rootcause/source/utils.cs
+++ b/Sources/Rootcause/source/utils.cs
@@ -254,7 +254,7 @@ namespace Rootcause
             public int partition = -1;
             public override GotoCmd VisitGotoCmd(GotoCmd node)
             {
-                var label = node.labelNames;
+                var label = node.LabelNames;
                 if (label != null && label.Count == 1 && label[0].Contains("AA_INSTR_EQ_BODY$1"))
                     partition = node.Line;
                 return base.VisitGotoCmd(node);
@@ -552,9 +552,9 @@ namespace Rootcause
             {
                 if (!(node.TransferCmd is GotoCmd)) return base.VisitBlock(node);
                 var g = node.TransferCmd as GotoCmd;
-                if (g.labelTargets.Count != 2) return base.VisitBlock(node); //goto A, B
-                var truet = g.labelTargets[0];
-                var falset = g.labelTargets[1];
+                if (g.LabelTargets.Count != 2) return base.VisitBlock(node); //goto A, B
+                var truet = g.LabelTargets[0];
+                var falset = g.LabelTargets[1];
                 if (!(truet.Cmds.Count > 0 && falset.Cmds.Count > 0)) return base.VisitBlock(node);
                 if (!(truet.Cmds[0] is AssumeCmd && falset.Cmds[0] is AssumeCmd)) return base.VisitBlock(node);
                 var condT = truet.Cmds[0] as AssumeCmd;
@@ -968,7 +968,7 @@ namespace Rootcause
                 //if (!(f.Name.Contains("CallMem") || f.Name.Contains("CallOut"))) { continue; }
                 //if (QKeyValue.FindBoolAttribute(f.Attributes, "uninterpreted"))
                 //if ((f.Name.Contains("CallMem") || f.Name.Contains("CallOut")))
-                if (QKeyValue.FindBoolAttribute(f.Attributes, "uninterpreted"))
+                if (f.Attributes.FindBoolAttribute("uninterpreted"))
                 {
                     //Make axioms of the form: forall x1, x2 :: f(x1) == f(x2) ==> x1 == x2
                     var inParams = f.InParams.Cast<Variable>();
@@ -1020,7 +1020,7 @@ namespace Rootcause
                         //find all functions with matching return
                         Function other_f = functions[iter_j];
                         if (other_f == f) { continue; }
-                        if (QKeyValue.FindBoolAttribute(other_f.Attributes, "uninterpreted"))
+                        if (other_f.Attributes.FindBoolAttribute("uninterpreted"))
                         {
                             if (other_f.OutParams.Count != f.OutParams.Count) { continue; }
                             bool matchingOutputs = true;

--- a/Sources/SymDiff/SymDiff.csproj
+++ b/Sources/SymDiff/SymDiff.csproj
@@ -113,16 +113,16 @@
     <ProjectReference Include="..\SymDiffUtils\SymDiffUtils.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="3.1.3" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.BaseTypes" Version="3.1.3" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
-    <PackageReference Include="Boogie.Houdini" Version="3.1.3" />
-    <PackageReference Include="Boogie.Graph" Version="3.1.3" />
-    <PackageReference Include="Boogie.Model" Version="3.1.3" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.1.3" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.1" />
+    <PackageReference Include="Boogie.BaseTypes" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Houdini" Version="3.5.1" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
+    <PackageReference Include="Boogie.Model" Version="3.5.1" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="source\ProcedureDriver.cs" />

--- a/Sources/SymDiff/SymDiff.csproj
+++ b/Sources/SymDiff/SymDiff.csproj
@@ -114,15 +114,15 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.1" />
-    <PackageReference Include="Boogie.BaseTypes" Version="3.5.1" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
-    <PackageReference Include="Boogie.Houdini" Version="3.5.1" />
-    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
-    <PackageReference Include="Boogie.Model" Version="3.5.1" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.2" />
+    <PackageReference Include="Boogie.BaseTypes" Version="3.5.2" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
+    <PackageReference Include="Boogie.Houdini" Version="3.5.2" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.2" />
+    <PackageReference Include="Boogie.Model" Version="3.5.2" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.2" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="source\ProcedureDriver.cs" />

--- a/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
+++ b/Sources/SymDiff/source/BoogieStructuralComparisonManager.cs
@@ -76,7 +76,7 @@ public class ImplementationComparer(BiDictionary<string, string> functionMapping
         if (blockA.TransferCmd is GotoCmd t1 &&
             blockB.TransferCmd is GotoCmd t2)
         {
-            foreach (var (blkTarget1, blkTarget2) in t1.labelTargets.Zip(t2.labelTargets))
+            foreach (var (blkTarget1, blkTarget2) in t1.LabelTargets.Zip(t2.LabelTargets))
             {
                 if (!localBlockMapping.TryAddIfNoConflict(blkTarget1, blkTarget2))
                 {

--- a/Sources/SymDiff/source/BoogieVerify.cs
+++ b/Sources/SymDiff/source/BoogieVerify.cs
@@ -10,6 +10,7 @@ using SymDiffUtils;
 using VC;
 using Util = SymDiffUtils.Util;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace SDiff
 {
@@ -183,7 +184,7 @@ namespace SDiff
                 RunningBoogieFromCommandLine = true
             };
             options.Parse(["/soundLoopUnrolling", "/inline:spec", "/printModel:1", "/removeEmptyBlocks:0", "/printModelToFile:model.dmp"]);
-            var engine = new ExecutionEngine(options, new VerificationResultCache());
+            var engine = new ExecutionEngine(options, new VerificationResultCache(), TaskScheduler.Current);
             if (engine == null) {
                 Log.Out (Log.Verifier, "Could not initialize Boogie verification engine");
             }
@@ -495,8 +496,8 @@ namespace SDiff
             Model[] errModelArray = errModelList.ToArray();
 
             var label = new GotoCmd(Token.NoToken, new List<String>() { "DONE" });
-            label.labelNames = new List<string>(); // label.labelTargets = new List<Block>();
-            label.labelNames.Add("DONE"); //label.labelTargets.Add("DONE");
+            label.LabelNames = new List<string>(); // label.labelTargets = new List<Block>();
+            label.LabelNames.Add("DONE"); //label.labelTargets.Add("DONE");
 
 
             // First block
@@ -509,11 +510,11 @@ namespace SDiff
 
             labels.Add("ELSE");
             var labelEntry = new GotoCmd(Token.NoToken, labels);
-            labelEntry.labelTargets = new List<Block>();
+            labelEntry.LabelTargets = new List<Block>();
 
             for (int j = 0; j < errors.Count; j++)
             {
-                labelEntry.labelNames.Add("Cex" + j);//labelEntry.labelTargets.Add("Cex" + j);
+                labelEntry.LabelNames.Add("Cex" + j);//labelEntry.labelTargets.Add("Cex" + j);
             }
 
             for (int i = 0; i < errors.Count; i++)

--- a/Sources/SymDiff/source/CorralCheck.cs
+++ b/Sources/SymDiff/source/CorralCheck.cs
@@ -32,7 +32,7 @@ namespace SDiff
             houdiniConsts = new HashSet<Constant>
             (mergedProg.TopLevelDeclarations
                 .OfType<Constant>()
-                .Where(x => QKeyValue.FindBoolAttribute(x.Attributes, "existential")));
+                .Where(x => x.Attributes.FindBoolAttribute("existential")));
         }
         public void CheckCandidateAsserts()
         {

--- a/Sources/SymDiff/source/Driver.cs
+++ b/Sources/SymDiff/source/Driver.cs
@@ -357,7 +357,7 @@ namespace SDiff
         var cmd = bl.TransferCmd;
         var gcmd = cmd as GotoCmd;
         if (gcmd == null) return "";
-        var blseq = ((GotoCmd)cmd).labelTargets;
+        var blseq = ((GotoCmd)cmd).LabelTargets;
         foreach(var b in blseq) {
             if (((Block)b).Label != "exit") //anything ohter than "exit"
                 return ((Block)b).Label;

--- a/Sources/SymDiff/source/MutualSummary.cs
+++ b/Sources/SymDiff/source/MutualSummary.cs
@@ -77,7 +77,7 @@ namespace SDiff
             if (!freeContractsIn)
                 Util.DropAllModifies(mergedProgram);
             ModSetCollector c = new ModSetCollector(BoogieUtils.BoogieOptions);
-            c.DoModSetAnalysis(mergedProgram); //important that we do it on the merged program
+            c.CollectModifies(mergedProgram); //important that we do it on the merged program
             //get the call graphs
             cg1 = CallGraph.Make(p1);
             cg2 = CallGraph.Make(p2);

--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -50,7 +50,7 @@ namespace SDiff
         #region Static variables, not options
         public static string MergedProgramOutputFile = "mergedProgSingle.bpl";
         public static HashSet<string> OutputVars = new HashSet<string>();
-        public static string BoogieUserOpts = "/doModSetAnalysis";
+        public static string BoogieUserOpts = "/inferModifies";
         public static bool ok; // *
         #endregion
 

--- a/Sources/SymDiff/source/SemanticTaint.cs
+++ b/Sources/SymDiff/source/SemanticTaint.cs
@@ -55,7 +55,7 @@ namespace SymDiff
         taintGuardConsts = new HashSet<Constant>();
         mergedProg.TopLevelDeclarations
             .OfType<Constant>()
-            .Where(x => QKeyValue.FindBoolAttribute(x.Attributes, "stmtTaintConst"))
+            .Where(x => x.Attributes.FindBoolAttribute("stmtTaintConst"))
             .ForEach(x => taintGuardConsts.Add(x));
       }
       private HashSet<Tuple<string,string>> GatherProcedureBlocksInConstants(IEnumerable<Constant> consts)

--- a/Sources/SymDiff/source/SymExec.cs
+++ b/Sources/SymDiff/source/SymExec.cs
@@ -351,13 +351,13 @@ namespace SDiff.SymEx
         if (jmp != null)
         {
           if (i + 1 < trace.Count)
-            if (!jmp.labelTargets.HasByLabel(trace[i + 1]))
+            if (!jmp.LabelTargets.HasByLabel(trace[i + 1]))
             {
               //boogie creates some "header" blocks that we can safely ignore. the condition for this is that
               // the actual next block is a suffix of the block it creates.
-              if (jmp.labelTargets.HasByLabelSuffix(trace[i + 1]))
+              if (jmp.LabelTargets.HasByLabelSuffix(trace[i + 1]))
                 continue;
-              Log.Out(Log.Error, "Missing block in trace: jumps to " + jmp.labelTargets.ToString() + " but next block is " + trace[i + 1].Label);
+              Log.Out(Log.Error, "Missing block in trace: jumps to " + jmp.LabelTargets.ToString() + " but next block is " + trace[i + 1].Label);
               return true;
             }
           //if (jmp.labelTargets.Length != 1)

--- a/Sources/SymDiff/source/Transform.cs
+++ b/Sources/SymDiff/source/Transform.cs
@@ -408,7 +408,7 @@ namespace SDiff
       if (Options.refinedStmtTaint)
       {
           Options.OutputVars.Clear();
-          globals.Where(x => QKeyValue.FindBoolAttribute(x.Attributes, "stmtTaintCollectorGlobalVar")).ForEach(x => Options.OutputVars.Add(x.ToString()));
+          globals.Where(x => x.Attributes.FindBoolAttribute("stmtTaintCollectorGlobalVar")).ForEach(x => Options.OutputVars.Add(x.ToString()));
       }
 
       List<Ensures> outputPostConditions = new List<Ensures>();

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -645,7 +645,7 @@ namespace SDiff
                     List<Counterexample> errors;
                     List<VerificationRunResult> vcResults;
                     (outcome, errors, vcResults) =
-                        vcgen.VerifyImplementation2(new ImplementationRun(n, Console.Out), CancellationToken.None).Result;
+                        vcgen.VerifyImplementationDirectly(new ImplementationRun(n, Console.Out), CancellationToken.None).Result;
                 }
                 catch (Exception e)
                 {
@@ -914,9 +914,9 @@ namespace SDiff
                         List<Cmd> entryCmd = new List<Cmd>();
                         var labelEntry = new GotoCmd(Token.NoToken, new List<String>() { "THEN", "ELSE" });
                         //labelEntry.labelTargets = new List<Block>();
-                        labelEntry.labelNames = new List<string>();
-                        labelEntry.labelNames.Add("THEN");
-                        labelEntry.labelNames.Add("ELSE");
+                        labelEntry.LabelNames = new List<string>();
+                        labelEntry.LabelNames.Add("THEN");
+                        labelEntry.LabelNames.Add("ELSE");
                         //labelEntry.labelTargets.Add("THEN");
                         //labelEntry.labelTargets.Add("ELSE");
                         Block entryBl = new Block(Token.NoToken, "ENTRY", entryCmd, labelEntry);
@@ -927,16 +927,16 @@ namespace SDiff
                         bodyThen.Add(ccmdThen);
                         var labelThen = new GotoCmd(Token.NoToken, new List<String>() { "DONE" });
                         //labelThen.labelTargets = new List<Block>();
-                        labelThen.labelNames = new List<string>();
-                        labelEntry.labelNames.Add("DONE");
+                        labelThen.LabelNames = new List<string>();
+                        labelEntry.LabelNames.Add("DONE");
                         //labelThen.labelTargets.Add("DONE");
                         Block thenBl = new Block(Token.NoToken, "THEN", bodyThen, labelThen);
 
                         // Third block
                         var labelElse = new GotoCmd(Token.NoToken, new List<String>() { "DONE" });
                         //labelElse.labelTargets = new List<Block>();
-                        labelElse.labelNames = new List<string>();
-                        labelElse.labelNames.Add("DONE");
+                        labelElse.LabelNames = new List<string>();
+                        labelElse.LabelNames.Add("DONE");
                         //labelElse.labelTargets.Add("DONE");
                         List<Cmd> bodyElse = new List<Cmd>();
                         bodyElse.Add(new AssumeCmd(Token.NoToken, Expr.False));

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -385,7 +385,7 @@ namespace SDiff
             //Program mergedProgram = new Program();
             //mergedProgram.TopLevelDeclarations = p2.TopLevelDeclarations.Append(p1.TopLevelDeclarations.ToList());
             Log.Out(Log.Normal, "Resolving and typechecking");
-            Boogie.Process.InitializeBoogie("/doModSetAnalysis");
+            Boogie.Process.InitializeBoogie("/inferModifies");
             if (BoogieUtils.ResolveAndTypeCheckThrow(mergedProgram, Options.MergedProgramOutputFile, BoogieUtils.BoogieOptions))
                 return 1;
 

--- a/Sources/SymDiffPostProcess/SymDiffPostProcess.csproj
+++ b/Sources/SymDiffPostProcess/SymDiffPostProcess.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
-    <PackageReference Include="Boogie.Graph" Version="3.1.3" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.1.3" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
   </ItemGroup>
 </Project>

--- a/Sources/SymDiffPostProcess/SymDiffPostProcess.csproj
+++ b/Sources/SymDiffPostProcess/SymDiffPostProcess.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
-    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.2" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.2" />
   </ItemGroup>
 </Project>

--- a/Sources/SymDiffPreProcess/SymDiffPreProcess.csproj
+++ b/Sources/SymDiffPreProcess/SymDiffPreProcess.csproj
@@ -15,6 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
   </ItemGroup>
 </Project>

--- a/Sources/SymDiffPreProcess/SymDiffPreProcess.csproj
+++ b/Sources/SymDiffPreProcess/SymDiffPreProcess.csproj
@@ -15,6 +15,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
   </ItemGroup>
 </Project>

--- a/Sources/SymDiffPreProcess/source/PreProcess.cs
+++ b/Sources/SymDiffPreProcess/source/PreProcess.cs
@@ -89,7 +89,7 @@ namespace SymdiffPreprocess
             if (errors > 0)
                 throw new ArgumentException("Unable to resolve " + programFileName);
             ModSetCollector c = new ModSetCollector(BoogieUtils.BoogieOptions);
-            c.DoModSetAnalysis(program);
+            c.CollectModifies(program);
             errors = program.Typecheck(BoogieUtils.BoogieOptions);
             if (errors > 0)
                 throw new ArgumentException("Unable to typecheck " + programFileName);

--- a/Sources/SymDiffPreProcess/source/SmackPreprocessorTransform.cs
+++ b/Sources/SymDiffPreProcess/source/SmackPreprocessorTransform.cs
@@ -181,10 +181,11 @@ namespace SymdiffPreprocess
                     continue;
                 }
                 //start a new block when you see an Assert Cmd with sourceline
-                nxtBlock = new Block();
-                nxtBlock.Cmds = new List<Cmd>() { cmd };
-                nxtBlock.Label = b.Label + "_splitSourceLine_" + splitBlocks.Count;
-                currBlock.TransferCmd = new GotoCmd(Token.NoToken, new List<Block>() { nxtBlock });
+                nxtBlock = new Block(
+                    Token.NoToken,
+                    b.Label + "_splitSourceLine_" + splitBlocks.Count, 
+                    new List<Cmd>() { cmd },
+                    new GotoCmd(Token.NoToken, new List<Block>() { nxtBlock }));
                 splitBlocks.Add(nxtBlock);
                 currBlock = nxtBlock;
             }
@@ -201,7 +202,7 @@ namespace SymdiffPreprocess
         // This transformation will not work in that case(maybe)?
         public override Block VisitBlock(Block node)
         {
-            foreach (Cmd cmd in node.cmds)
+            foreach (Cmd cmd in node.Cmds)
             {
                 if (cmd is AssignCmd)
                 {                    

--- a/Sources/SymDiffUtils/HoudiniInferredFilter.cs
+++ b/Sources/SymDiffUtils/HoudiniInferredFilter.cs
@@ -91,7 +91,7 @@ namespace SymDiffUtils
             procsToAnalyze = procs;
             callGraph = CallGraphHelper.ComputeCallGraph(prog);
             this.candidateConsts = this.prog.Variables.Where(Item => 
-                QKeyValue.FindBoolAttribute(Item.Attributes, "existential")).Select(Item => Item.Name).ToList();
+                Item.Attributes.FindBoolAttribute("existential")).Select(Item => Item.Name).ToList();
         }
 
         public override Program VisitProgram(Program node)
@@ -136,8 +136,8 @@ namespace SymDiffUtils
         {
             var tmp = base.VisitProgram(node);
             var unused = node.TopLevelDeclarations.OfType<Variable>()
-                .Where(x => (QKeyValue.FindBoolAttribute(x.Attributes, "existential") &&
-                    !usedExistentialConstants.Contains(x)));
+                .Where(x => (x.Attributes.FindBoolAttribute("existential")) &&
+                    !usedExistentialConstants.Contains(x));
             Console.WriteLine("HoudiniPruneUnusedExistentialConstants: Removing [{0}]",
                 string.Join(",", unused.Select(x => x.Name)));
             node.RemoveTopLevelDeclarations(x => unused.Contains(x)); 
@@ -147,7 +147,7 @@ namespace SymDiffUtils
         {
             VariableCollector vc = new VariableCollector();
             vc.Visit(node);
-            var existConsts = vc.usedVars.Where(x => QKeyValue.FindBoolAttribute(x.Attributes, "existential"));
+            var existConsts = vc.usedVars.Where(x => x.Attributes.FindBoolAttribute("existential"));
             existConsts.ForEach(x => usedExistentialConstants.Add(x));
             return base.VisitIdentifierExpr(node);
         }

--- a/Sources/SymDiffUtils/SymDiffUtils.csproj
+++ b/Sources/SymDiffUtils/SymDiffUtils.csproj
@@ -7,13 +7,13 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.1" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
-    <PackageReference Include="Boogie.Houdini" Version="3.5.1" />
-    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
-    <PackageReference Include="Boogie.Model" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
+    <PackageReference Include="Boogie.Houdini" Version="3.5.2" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.2" />
+    <PackageReference Include="Boogie.Model" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.2" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.2" />
   </ItemGroup>
 </Project>

--- a/Sources/SymDiffUtils/SymDiffUtils.csproj
+++ b/Sources/SymDiffUtils/SymDiffUtils.csproj
@@ -7,13 +7,13 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Boogie.ExecutionEngine" Version="3.1.3" />
+    <PackageReference Include="Boogie.ExecutionEngine" Version="3.5.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
-    <PackageReference Include="Boogie.Houdini" Version="3.1.3" />
-    <PackageReference Include="Boogie.Graph" Version="3.1.3" />
-    <PackageReference Include="Boogie.Model" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCExpr" Version="3.1.3" />
-    <PackageReference Include="Boogie.VCGeneration" Version="3.1.3" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Houdini" Version="3.5.1" />
+    <PackageReference Include="Boogie.Graph" Version="3.5.1" />
+    <PackageReference Include="Boogie.Model" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCExpr" Version="3.5.1" />
+    <PackageReference Include="Boogie.VCGeneration" Version="3.5.1" />
   </ItemGroup>
 </Project>

--- a/Sources/SymDiffUtils/TaintBasedSimplification.cs
+++ b/Sources/SymDiffUtils/TaintBasedSimplification.cs
@@ -17,7 +17,7 @@ namespace SymDiffUtils
         {            
             this.program = p;
             this.candidateConsts = this.program.Variables.Where(Item =>
-                QKeyValue.FindBoolAttribute(Item.Attributes, "existential")).Select(Item => Item.Name).ToList();
+                Item.Attributes.FindBoolAttribute("existential")).Select(Item => Item.Name).ToList();
             this.procs = this.program.Procedures.Select(proc => new { proc.Name, x = proc }).ToDictionary(x => x.Name, x => x.x);            
         }
 
@@ -154,7 +154,7 @@ namespace SymDiffUtils
         {
             this.program = p;
             this.candidateConsts = this.program.Variables.Where(Item =>
-                QKeyValue.FindBoolAttribute(Item.Attributes, "existential")).Select(Item => Item.Name).ToList();
+                Item.Attributes.FindBoolAttribute("existential")).Select(Item => Item.Name).ToList();
             this.procs = this.program.Procedures.Select(proc => new { proc.Name, x = proc }).ToDictionary(x => x.Name, x => x.x);
             this.SIMPLIFICATION_COMMENT = comment;
             this.FILTERING_REASON = filteringReason;

--- a/Sources/SyntaxDiff/SyntaxDiff.csproj
+++ b/Sources/SyntaxDiff/SyntaxDiff.csproj
@@ -11,8 +11,8 @@
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Common, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Controls, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <ProjectReference Include="..\Corral\source\ProgTransformation\ProgTransformation.csproj" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
-    <PackageReference Include="Boogie.Core" Version="3.5.1" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.2" />
+    <PackageReference Include="Boogie.Core" Version="3.5.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SymDiffUtils\SymDiffUtils.csproj" />

--- a/Sources/SyntaxDiff/SyntaxDiff.csproj
+++ b/Sources/SyntaxDiff/SyntaxDiff.csproj
@@ -11,8 +11,8 @@
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Common, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.TeamFoundation.VersionControl.Controls, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <ProjectReference Include="..\Corral\source\ProgTransformation\ProgTransformation.csproj" />
-    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.1.3" />
-    <PackageReference Include="Boogie.Core" Version="3.1.3" />
+    <PackageReference Include="Boogie.Provers.SMTLib" Version="3.5.1" />
+    <PackageReference Include="Boogie.Core" Version="3.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SymDiffUtils\SymDiffUtils.csproj" />


### PR DESCRIPTION
Most of the changes are trivial, to adapt to changed field/property names and slightly different APIs. The changes that could use reviewing are to these files:
* Sources/SymDiff/source/BlockOutliner.cs (most substantial)
* Sources/SymDiff/source/LoopExtractor.cs (functionality removed, some slightly subtle changes changes)
* Sources/Dependency/source/RefineDependency.cs (just around line 399)

These simpler changed files could probably also use a second glance:
* Sources/BoogieWrapper/source/Wrapper.cs
* Sources/Dependency/source/Analysis.cs
* Sources/Dependency/source/RefineDependency.cs

The rest of the changes you can probably assume to be fine given that it still compiles.