### PR TITLE
Disable adding additional modifies

### DIFF
--- a/Sources/SymDiff/source/Options.cs
+++ b/Sources/SymDiff/source/Options.cs
@@ -41,7 +41,7 @@ namespace SDiff
 
         // global variables with these strings in their name will be assumed to be modified in procedures with no
         // implementations and no modifies clauses
-        public static List<string> HeapStringIdentifiers = ["heap", "Heap"];
+        public static List<string> HeapStringIdentifiers = []; // ["heap", "Heap"];
 
         //mode where a procedure is inlined when not equal (non-recursive only) [For evaluation of diff inlining]
         public const bool InlineWhenFail = false; //make sure DifferentialInline is turned off

--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -1878,6 +1878,7 @@ namespace SDiff
             var globalsToAssumeModifiedP1 = p1.GlobalVariables
                 .Where(v => Options.HeapStringIdentifiers.Any(id => v.Name.Contains(id)))
                 .Select(v => new IdentifierExpr(Token.NoToken, v)).ToList();
+            Debug.Assert(globalsToAssumeModifiedP1.Count == 0);
 
             var globalsToAssumeModifiedP2 = new List<IdentifierExpr>();
             if (Options.CustomHeapComparison) {
@@ -1889,6 +1890,7 @@ namespace SDiff
                     .Where(v => Options.HeapStringIdentifiers.Any(id => v.Name.Contains(id)))
                     .Select(v => new IdentifierExpr(Token.NoToken, v)).ToList();
             }
+            Debug.Assert(globalsToAssumeModifiedP2.Count == 0);
 
             foreach (var proc in p1.Procedures)
             {


### PR DESCRIPTION
SymDiff adds `modifies g1 ... gn` to the spec for every procedure with an empty modifies clause where `g1 ... gn` are any globals with names that include "heap" or "Heap" as a substring. This PR disables this feature.

@typerSniper @atomb 