### PR TITLE
Restructure programs so that constants show up before globals

### DIFF
--- a/Sources/SymDiff/source/WholeProgram.cs
+++ b/Sources/SymDiff/source/WholeProgram.cs
@@ -362,8 +362,8 @@ namespace SDiff
             // restructuring the order of declarations
             Program p1 = new Program();
             p1.AddTopLevelDeclarations(typeDeclsP);
-            p1.AddTopLevelDeclarations(globDeclsP);
             p1.AddTopLevelDeclarations(consDeclsP);
+            p1.AddTopLevelDeclarations(globDeclsP);
             p1.AddTopLevelDeclarations(funcDeclsP);
             p1.AddTopLevelDeclarations(axiomDeclsP);
             p1.AddTopLevelDeclarations(procDeclsP);


### PR DESCRIPTION
Globals in Boogie can reference constants, but constants cannot refer to globals. This PR changes the `RestructureProgram` method to respect this.

This fixes an issue with the visitor that rename's declarations during product program construction: constants weren't being renamed before globals, causing type errors if the input program has a global with a `where` clause that refers to a constant.